### PR TITLE
fix: import error

### DIFF
--- a/hugegraph-python/example/client_test.py
+++ b/hugegraph-python/example/client_test.py
@@ -2,7 +2,8 @@ import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from example.test_hugegraph import HugeGraph
+from example.hugegraph_test import HugeGraph
+
 
 class HugeGraphTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
### fix Description
In the code located at example/client_test.py, there is an import error. The code incorrectly attempts to import the HugeGraph class from the example.test_hugegraph module. However, the correct module should be example.hugegraph_test.

### Solution
I have fixed this issue by modifying the import statement in example/client_test.py from:

```from example.test_hugegraph import HugeGraph```
to
```from example.hugegraph_test import HugeGraph```