### PR TITLE
fix: base-ref/head-ref missed in dependency-check-ci on branch push

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -1,10 +1,6 @@
 name: "3rd-party check"
 
 on:
-  push:
-    branches:
-      - main
-      - 'release-*'
   pull_request:
 
 permissions:


### PR DESCRIPTION
refer to https://github.com/apache/incubator-hugegraph/pull/2308