### PR TITLE
fix: fusiform_similarity test in traverser for server 1.3.0

### DIFF
--- a/.github/workflows/hugegraph-python-client.yml
+++ b/.github/workflows/hugegraph-python-client.yml
@@ -26,7 +26,7 @@ jobs:
         pip install -r ./hugegraph-python-client/requirements.txt
     - name: Prepare HugeGraph Server Environment
       run: |
-        docker run -d --name=graph -p 8080:8080 -e PASSWORD=admin hugegraph/hugegraph:1.2.0
+        docker run -d --name=graph -p 8080:8080 -e PASSWORD=admin hugegraph/hugegraph:1.3.0
         sleep 20
     - name: Test example
       run: |

--- a/.github/workflows/hugegraph-python-client.yml
+++ b/.github/workflows/hugegraph-python-client.yml
@@ -10,12 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/hugegraph-python-client/src/tests/api/test_traverser.py
+++ b/hugegraph-python-client/src/tests/api/test_traverser.py
@@ -208,7 +208,7 @@ class TestTraverserManager(unittest.TestCase):
             ],
         )
 
-        sources = {"ids": [marko], "label": "person", "properties": {}}
+        sources = {"ids": [marko]}
         fusiform_similarity_result = self.traverser.fusiform_similarity(
             sources,
             label="knows",


### PR DESCRIPTION
faild jobs: https://github.com/apache/incubator-hugegraph-ai/actions/runs/8673001982/job/23783894307

doc: https://hugegraph.apache.org/cn/docs/clients/restful-api/traverser/#3221-fusiform-similarity

![image](https://github.com/apache/incubator-hugegraph-ai/assets/42756849/0941084a-38ac-4ea4-b8c7-6d8f709f9f09)

pass in 1.2 and fail in 1.3?

Related PR: https://github.com/apache/incubator-hugegraph/pull/2458