### PR TITLE
chore: introduce black for code format in github actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,4 @@
-name: "Lint"
+name: "Black"
 
 on:
   push:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
+        with:
+          src: "hugegraph-llm/src hugegraph-python-client/src"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          options: "--check --verbose --line-length 100"
+          options: "--check --diff --line-length 100"
           src: "hugegraph-llm/src hugegraph-python-client/src"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - uses: psf/black@3702ba224ecffbcec30af640c149f231d90aebdb
         with:
           options: "--check --diff --line-length 100"
           src: "hugegraph-llm/src hugegraph-python-client/src"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,4 @@
-name: "Format code"
+name: "Lint"
 
 on:
   push:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,14 @@
+name: "Format code"
+
+on:
+  push:
+    branches:
+      - 'release-*'
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,4 @@
-name: "Black"
+name: "Black Code Formatter"
 
 on:
   push:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,4 +13,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
+          options: "--check --verbose --line-length 100"
           src: "hugegraph-llm/src hugegraph-python-client/src"


### PR DESCRIPTION
According to https://github.com/apache/incubator-hugegraph-ai/issues/46, I think black for code format can be supported by black integration with github actions([black.readthedocs.io/en/stable/integrations/github_actions.html](https://black.readthedocs.io/en/stable/integrations/github_actions.html)).

the workflow fails if Black finds files that need to be formatted, as can be seen in https://github.com/ChenZiHong-Gavin/incubator-hugegraph-ai/pull/17
![image](https://github.com/apache/incubator-hugegraph-ai/assets/58508660/b42dde7d-b111-47a9-8d44-c9c0dd81a592)

so i think everyone should run black in ./style/code_format_and_analysis.sh before commit. (Perhaps it would be better to automatically trigger [the process] through GitHub Hooks rather than running it manually.)

after that, Black passes the workflow, as can be seen in https://github.com/ChenZiHong-Gavin/incubator-hugegraph-ai/pull/18
![image](https://github.com/apache/incubator-hugegraph-ai/assets/58508660/fd3a9749-40ea-402c-ba2d-7948d4386fc3)
