### PR TITLE
feat(llm): add auth for fastapi and gradio

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from fastapi import FastAPI, status
+from fastapi import status, APIRouter
 
 from hugegraph_llm.api.models.rag_response import RAGResponse
 from hugegraph_llm.config import settings
@@ -23,8 +23,8 @@ from hugegraph_llm.api.models.rag_requests import RAGRequest, GraphConfigRequest
 from hugegraph_llm.api.exceptions.rag_exceptions import generate_response
 
 
-def rag_http_api(app: FastAPI, rag_answer_func, apply_graph_conf, apply_llm_conf, apply_embedding_conf):
-    @app.post("/rag", status_code=status.HTTP_200_OK)
+def rag_http_api(router: APIRouter, rag_answer_func, apply_graph_conf, apply_llm_conf, apply_embedding_conf):
+    @router.post("/rag", status_code=status.HTTP_200_OK)
     def rag_answer_api(req: RAGRequest):
         result = rag_answer_func(req.query, req.raw_llm, req.vector_only, req.graph_only, req.graph_vector)
         return {
@@ -33,13 +33,13 @@ def rag_http_api(app: FastAPI, rag_answer_func, apply_graph_conf, apply_llm_conf
             if getattr(req, key)
         }
 
-    @app.post("/config/graph", status_code=status.HTTP_201_CREATED)
+    @router.post("/config/graph", status_code=status.HTTP_201_CREATED)
     def graph_config_api(req: GraphConfigRequest):
         # Accept status code
         res = apply_graph_conf(req.ip, req.port, req.name, req.user, req.pwd, req.gs, origin_call="http")
         return generate_response(RAGResponse(status_code=res, message="Missing Value"))
 
-    @app.post("/config/llm", status_code=status.HTTP_201_CREATED)
+    @router.post("/config/llm", status_code=status.HTTP_201_CREATED)
     def llm_config_api(req: LLMConfigRequest):
         settings.llm_type = req.llm_type
 
@@ -53,7 +53,7 @@ def rag_http_api(app: FastAPI, rag_answer_func, apply_graph_conf, apply_llm_conf
             res = apply_llm_conf(req.host, req.port, req.language_model, None, origin_call="http")
         return generate_response(RAGResponse(status_code=res, message="Missing Value"))
 
-    @app.post("/config/embedding", status_code=status.HTTP_201_CREATED)
+    @router.post("/config/embedding", status_code=status.HTTP_201_CREATED)
     def embedding_config_api(req: LLMConfigRequest):
         settings.embedding_type = req.llm_type
 

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_web_demo.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_web_demo.py
@@ -54,6 +54,7 @@ def authenticate(credentials: HTTPAuthorizationCredentials = Depends(sec)):
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+
 def rag_answer(
         text: str, raw_answer: bool, vector_only_answer: bool, graph_only_answer: bool, graph_vector_answer: bool
 ) -> tuple:
@@ -476,12 +477,13 @@ if __name__ == "__main__":
     app_auth = APIRouter(dependencies=[Depends(authenticate)])
 
     hugegraph_llm = init_rag_ui()
-
     rag_http_api(app_auth, rag_answer, apply_graph_config, apply_llm_config, apply_embedding_config)
 
     app.include_router(app_auth)
-
-    app = gr.mount_gradio_app(app, hugegraph_llm, path="/", auth=("rag", os.getenv("TOKEN")) if os.getenv("ENABLE_LOGIN") == "True" else None)
+    auth_enabled = os.getenv("ENABLE_LOGIN", "False").lower() == "true"
+    log.info("Authentication is %s.", "enabled" if auth_enabled else "disabled")
+    # TODO: support multi-user login when need
+    app = gr.mount_gradio_app(app, hugegraph_llm, path="/", auth=("rag", os.getenv("TOKEN")) if auth_enabled else None)
 
     # Note: set reload to False in production environment
     uvicorn.run(app, host=args.host, port=args.port)

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_web_demo.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_web_demo.py
@@ -25,7 +25,7 @@ import gradio as gr
 import requests
 import uvicorn
 from fastapi import FastAPI, Depends, APIRouter
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials, OAuth2PasswordBearer
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from requests.auth import HTTPBasicAuth
 
 from hugegraph_llm.api.rag_api import rag_http_api


### PR DESCRIPTION
1. add auth to gradio(using auth provided by gradio)
auth – If provided, username and password (or list of username-password tuples) required to access the gradio app. Can also provide function that takes username and password and returns True if valid login.
refer: https://www.gradio.app/main/docs/gradio/blocks
2. add auth to fastapi(using APIRouter)
refer: https://fastapi.tiangolo.com/reference/apirouter/#fastapi.APIRouter