### PR TITLE
fix(llm): the profile regenerate feature

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/config/__init__.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/__init__.py
@@ -24,7 +24,7 @@ from .config import Config, PromptConfig
 settings = Config()
 settings.from_env()
 prompt = PromptConfig()
-
+prompt.ensure_yaml_file_exists()
 
 package_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 resource_path = os.path.join(package_path, "resources")

--- a/hugegraph-llm/src/hugegraph_llm/config/config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/config.py
@@ -45,6 +45,7 @@ def read_dotenv() -> dict[str, Optional[str]]:
 
 @dataclass
 class Config(ConfigData):
+
     def from_env(self):
         if os.path.exists(env_path):
             env_config = read_dotenv()
@@ -58,7 +59,7 @@ class Config(ConfigData):
 
     def generate_env(self):
         if os.path.exists(env_path):
-            log.info("%s already exists, do you want to update it? (y/n)", env_path)
+            log.info("%s already exists, do you want to override with the default configuration? (y/n)", env_path)
             update = input()
             if update.lower() != "y":
                 return
@@ -89,9 +90,6 @@ class Config(ConfigData):
 
 class PromptConfig(PromptData):
 
-    def __init__(self):
-        self.ensure_yaml_file_exists()
-
     def ensure_yaml_file_exists(self):
         if os.path.exists(yaml_file_path):
             log.info("Loading prompt file '%s' successfully.", F_NAME)
@@ -101,7 +99,7 @@ class PromptConfig(PromptData):
                 for key, value in data.items():
                     setattr(self, key, value)
         else:
-            self.save_to_yaml()
+            self.generate_yaml_file()
             log.info("Prompt file '%s' doesn't exist, create it.", yaml_file_path)
 
 
@@ -134,6 +132,16 @@ answer_prompt: |
         with open(yaml_file_path, "w", encoding="utf-8") as file:
             file.write(yaml_content)
 
+    def generate_yaml_file(self):
+        if os.path.exists(yaml_file_path):
+            log.info("%s already exists, do you want to override with the default configuration? (y/n)", yaml_file_path)
+            update = input()
+            if update.lower() != "y":
+                return
+            self.save_to_yaml()
+        else:
+            self.save_to_yaml()
+            log.info("Prompt file '%s' doesn't exist, create it.", yaml_file_path)
 
     def update_yaml_file(self):
         self.save_to_yaml()

--- a/hugegraph-llm/src/hugegraph_llm/config/generate.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/generate.py
@@ -18,11 +18,12 @@
 
 import argparse
 
-from hugegraph_llm.config import settings
+from hugegraph_llm.config import Config, PromptConfig
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate hugegraph-llm config file")
     parser.add_argument("-U", "--update", action="store_true", help="Update the config file")
     args = parser.parse_args()
     if args.update:
-        settings.generate_env()
+        Config().generate_env()
+        PromptConfig().generate_yaml_file()


### PR DESCRIPTION
# diagnosing for improvement

This PR solves the problem that the function of regenerating the configuration file fails. 

The core problem is that the default configuration file will be overwritten by the existing configuration file according to the original program logic after it is read into memory

# problem solution

Therefore, the goal of this solution is to generate an instance of the configuration class initialized in the `config.generate` part of the function, and process it separately instead of reading the content of the existing configuration file

# Test(passed)

use `python3 -m hugegraph_llm.config.generate --update`

![image](https://github.com/user-attachments/assets/dd2907bf-47c2-4692-ab0d-27459e3550df)
