### PR TITLE
fix: lowercase the repo label

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,7 +29,7 @@ github:
   labels:
     - graphrag
     - graph-machine-learning
-    - GNN
+    - gnn
     - knowledge-graph
     - hugegraph
   enabled_merge_buttons:


### PR DESCRIPTION

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/e2da4023-3539-452f-9adb-bead2827ae1a">
