### PR TITLE
chore(dist): exclude binary files when exporting source package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,9 @@
 .asf.yaml export-ignore
 apache-release.sh export-ignore
 .licenserc.yaml export-ignore
-questions_template.xlsx export-ignore
+*.xlsx export-ignore
+*.pdf export-ignore
+*.docx export-ignore
 
 # ignored directory
 .github/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 .asf.yaml export-ignore
 apache-release.sh export-ignore
 .licenserc.yaml export-ignore
+questions_template.xlsx export-ignore
 
 # ignored directory
 .github/ export-ignore


### PR DESCRIPTION
As title.