### PR TITLE
fix(llm): answer prompt None value effect

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
@@ -43,7 +43,7 @@ class GraphRAGRequest(BaseModel):
     rerank_method: Literal["bleu", "reranker"] = "bleu"
     near_neighbor_first: bool = False
     custom_priority_info: str = ""
-    answer_prompt: str = ""
+    answer_prompt: Optional[str] = None
 
 
 class GraphConfigRequest(BaseModel):

--- a/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
@@ -30,7 +30,7 @@ class RAGRequest(BaseModel):
     rerank_method: Literal["bleu", "reranker"] = "bleu"
     near_neighbor_first: bool = False
     custom_priority_info: str = ""
-    answer_prompt: str = ""
+    answer_prompt: Optional[str] = None
 
 
 class GraphRAGRequest(BaseModel):

--- a/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
@@ -27,7 +27,7 @@ from hugegraph_llm.api.models.rag_requests import (
     RerankerConfigRequest, GraphRAGRequest,
 )
 from hugegraph_llm.api.models.rag_response import RAGResponse
-from hugegraph_llm.config import settings
+from hugegraph_llm.config import settings, prompt
 from hugegraph_llm.utils.log import log
 
 
@@ -63,7 +63,7 @@ def rag_http_api(
             req.rerank_method,
             req.near_neighbor_first,
             req.custom_priority_info,
-            req.answer_prompt
+            req.answer_prompt or prompt.answer_prompt
         )
         return {
             key: value


### PR DESCRIPTION
Solve the problem that the final result is not as expected when the `answer_prompt` in the body parameter of `/rag` api is `None` or an empty string