### PR TITLE
fix(llm): replace getenv usage to settings

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/api/admin_api.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/admin_api.py
@@ -22,12 +22,14 @@ from fastapi.responses import StreamingResponse
 from hugegraph_llm.api.exceptions.rag_exceptions import generate_response
 from hugegraph_llm.api.models.rag_requests import LogStreamRequest
 from hugegraph_llm.api.models.rag_response import RAGResponse
+from hugegraph_llm.config import admin_settings
+
 
 # FIXME: line 31: E0702: Raising dict while only classes or instances are allowed (raising-bad-type)
 def admin_http_api(router: APIRouter, log_stream):
     @router.post("/logs", status_code=status.HTTP_200_OK)
     async def log_stream_api(req: LogStreamRequest):
-        if os.getenv('ADMIN_TOKEN') != req.admin_token:
+        if admin_settings.admin_token != req.admin_token:
             raise generate_response(RAGResponse(status_code=status.HTTP_403_FORBIDDEN, message="Invalid admin_token")) #pylint: disable=E0702
         log_path = os.path.join("logs", req.log_file)
 

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/admin_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/admin_block.py
@@ -16,12 +16,12 @@
 # under the License.
 
 import asyncio
-import os
 from collections import deque
 
 import gradio as gr
 from gradio import Request
 
+from hugegraph_llm.config import admin_settings
 from hugegraph_llm.utils.log import log
 
 
@@ -72,7 +72,7 @@ def clear_llm_server_log():
 # Function to validate password and control access to logs
 def check_password(password, request: Request = None):
     client_ip = request.client.host if request else "Unknown IP"
-    admin_token = os.getenv('ADMIN_TOKEN')
+    admin_token = admin_settings.admin_token
 
     if password == admin_token:
         # Return logs and update visibility

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
@@ -17,7 +17,6 @@
 
 
 import argparse
-import os
 
 import gradio as gr
 import uvicorn
@@ -26,7 +25,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from hugegraph_llm.api.admin_api import admin_http_api
 from hugegraph_llm.api.rag_api import rag_http_api
-from hugegraph_llm.config import huge_settings, prompt
+from hugegraph_llm.config import admin_settings, huge_settings, prompt
 from hugegraph_llm.demo.rag_demo.admin_block import create_admin_block, log_stream
 from hugegraph_llm.demo.rag_demo.configs_block import (
     create_configs_block,
@@ -46,7 +45,7 @@ sec = HTTPBearer()
 
 
 def authenticate(credentials: HTTPAuthorizationCredentials = Depends(sec)):
-    correct_token = os.getenv("USER_TOKEN")
+    correct_token = admin_settings.user_token
     if credentials.credentials != correct_token:
         from fastapi import HTTPException
 
@@ -148,7 +147,7 @@ if __name__ == "__main__":
     # settings.check_env()
     prompt.update_yaml_file()
 
-    auth_enabled = os.getenv("ENABLE_LOGIN", "False").lower() == "true"
+    auth_enabled = admin_settings.enable_login.lower() == "true"
     log.info("(Status) Authentication is %s now.", "enabled" if auth_enabled else "disabled")
     api_auth = APIRouter(dependencies=[Depends(authenticate)] if auth_enabled else [])
 
@@ -162,7 +161,7 @@ if __name__ == "__main__":
 
     # TODO: support multi-user login when need
     app = gr.mount_gradio_app(app, hugegraph_llm, path="/",
-                              auth=("rag", os.getenv("USER_TOKEN")) if auth_enabled else None)
+                              auth=("rag", admin_settings.user_token) if auth_enabled else None)
 
     # TODO: we can't use reload now due to the config 'app' of uvicorn.run
     # ❎:f'{__name__}:app' / rag_web_demo:app / hugegraph_llm.demo.rag_web_demo:app

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/configs_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/configs_block.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import json
-import os
 from functools import partial
 from typing import Optional
 
@@ -376,7 +375,7 @@ def create_configs_block() -> list:
     with gr.Accordion("4. Set up the Reranker.", open=False):
         reranker_dropdown = gr.Dropdown(
             choices=["cohere", "siliconflow", ("default/offline", "None")],
-            value=os.getenv("reranker_type") or "None",
+            value=llm_settings.reranker_type or "None",
             label="Reranker",
         )
 

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/rag_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/rag_block.py
@@ -24,7 +24,7 @@ import gradio as gr
 import pandas as pd
 from gradio.utils import NamedString
 
-from hugegraph_llm.config import resource_path, prompt, huge_settings
+from hugegraph_llm.config import resource_path, prompt, huge_settings, llm_settings
 from hugegraph_llm.operators.graph_rag_task import RAGPipeline
 from hugegraph_llm.utils.log import log
 
@@ -128,7 +128,7 @@ def create_rag_block():
 
             with gr.Column():
                 with gr.Row():
-                    online_rerank = os.getenv("reranker_type")
+                    online_rerank = llm_settings.reranker_type
                     rerank_method = gr.Dropdown(
                         choices=["bleu", ("rerank (online)", "reranker")] if online_rerank else ["bleu"],
                         value="reranker" if online_rerank else "bleu",

--- a/hugegraph-llm/src/hugegraph_llm/models/embeddings/qianfan.py
+++ b/hugegraph-llm/src/hugegraph_llm/models/embeddings/qianfan.py
@@ -18,8 +18,9 @@
 
 from typing import Optional, List
 
-import os
 import qianfan
+
+from hugegraph_llm.config import llm_settings
 
 """
 "QianFan" platform can be understood as a unified LLM platform that encompasses the 
@@ -37,8 +38,8 @@ class QianFanEmbedding:
             api_key: Optional[str] = None,
             secret_key: Optional[str] = None
     ):
-        qianfan.get_config().AK = api_key or os.getenv("QIANFAN_ACCESS_KEY")
-        qianfan.get_config().SK = secret_key or os.getenv("QIANFAN_SECRET_KEY")
+        qianfan.get_config().AK = api_key or llm_settings.qianfan_embedding_api_key
+        qianfan.get_config().SK = secret_key or llm_settings.qianfan_embedding_secret_key
         self.embedding_model_name = model_name
         self.client = qianfan.Embedding()
 

--- a/hugegraph-llm/src/hugegraph_llm/models/llms/qianfan.py
+++ b/hugegraph-llm/src/hugegraph_llm/models/llms/qianfan.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
 import json
 from typing import Optional, List, Dict, Any, Callable
 
 import qianfan
 from retry import retry
 
+from hugegraph_llm.config import llm_settings
 from hugegraph_llm.models.llms.base import BaseLLM
 from hugegraph_llm.utils.log import log
 
@@ -29,8 +29,8 @@ from hugegraph_llm.utils.log import log
 class QianfanClient(BaseLLM):
     def __init__(self, model_name: Optional[str] = "ERNIE-4.0-Turbo-8K",
                  api_key: Optional[str] = None, secret_key: Optional[str] = None):
-        qianfan.get_config().AK = api_key or os.getenv("QIANFAN_ACCESS_KEY")
-        qianfan.get_config().SK = secret_key or os.getenv("QIANFAN_SECRET_KEY")
+        qianfan.get_config().AK = api_key or llm_settings.qianfan_chat_api_key
+        qianfan.get_config().SK = secret_key or llm_settings.qianfan_chat_secret_key
         self.chat_model = model_name
         self.chat_comp = qianfan.ChatCompletion()
 


### PR DESCRIPTION
Since https://github.com/apache/incubator-hugegraph-ai/pull/122, we recommend:
- use `Config` class and its setting instances(e.g. `admin_settings`) to load configs
- not to use `os.getenv` directly because it may not the same with `.env` file. But if we set some values in environ, they will be automatically loaded into settings.