### PR TITLE
fix(llm): extract_graph_data use wrong method

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
@@ -76,7 +76,7 @@ def extract_graph(input_file, input_text, schema, example_prompt) -> str:
     error_message = parse_schema(schema, builder)
     if error_message:
         return error_message
-    builder.chunk_split(texts, "document", "zh").extract_info(example_prompt, "triples")
+    builder.chunk_split(texts, "document", "zh").extract_info(example_prompt, "property_graph")
 
     try:
         context = builder.run()


### PR DESCRIPTION
the `InfoExtract` corresponding to 'tripls' was incorrectly called; instead, the `PropertyGraphExtract` corresponding to 'property_graph' should have been called

So, change `extract_info(example_prompt, "triples")` to `extract_info(example_prompt, "property_graph")`