### PR TITLE
feat(llm): Modify the return messages of Get Vector Index Info and Get Graph Index Info

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/config/models/base_prompt_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/models/base_prompt_config.py
@@ -35,6 +35,7 @@ class BasePromptConfig:
     keywords_extract_prompt: str = ''
     text2gql_graph_schema: str = ''
     gremlin_generate_prompt: str = ''
+    doc_input_text: str = ''
 
     def ensure_yaml_file_exists(self):
         if os.path.exists(yaml_file_path):
@@ -61,6 +62,7 @@ class BasePromptConfig:
         indented_keywords_extract_template = (
             "\n".join([f"    {line}" for line in self.keywords_extract_prompt.splitlines()])
         )
+        indented_doc_input_text = "\n".join([f"  {line}" for line in self.doc_input_text.splitlines()])
 
         # This can be extended to add storage fields according to the data needs to be stored
         yaml_content = f"""graph_schema: |
@@ -86,6 +88,9 @@ keywords_extract_prompt: |
 
 gremlin_generate_prompt: |
 {indented_gremlin_prompt}
+
+doc_input_text: |
+{indented_doc_input_text}
 
 """
         with open(yaml_file_path, "w", encoding="utf-8") as file:

--- a/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
@@ -205,7 +205,7 @@ g.V().limit(10)
 The generated gremlin is:
 """
 
-    doc_input_text = """Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010. 
+    doc_input_text = """Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010.
 James, in his professional life, works as a journalist. Additionally, Sarah is the proud owner of the website 
 www.sarahsplace.com, while James manages his own webpage, though the specific URL is not mentioned here. 
 These two individuals, Sarah and James, have not only forged a strong personal bond as roommates but have also 

--- a/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
@@ -205,7 +205,7 @@ g.V().limit(10)
 The generated gremlin is:
 """
 
-    doc_input_text = """Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010.
+    doc_input_text: str = """Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010.
 James, in his professional life, works as a journalist. Additionally, Sarah is the proud owner of the website 
 www.sarahsplace.com, while James manages his own webpage, though the specific URL is not mentioned here. 
 These two individuals, Sarah and James, have not only forged a strong personal bond as roommates but have also 

--- a/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
@@ -204,3 +204,11 @@ g.V().limit(10)
 
 The generated gremlin is:
 """
+
+    doc_input_text = """Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010. 
+James, in his professional life, works as a journalist. Additionally, Sarah is the proud owner of the website 
+www.sarahsplace.com, while James manages his own webpage, though the specific URL is not mentioned here. 
+These two individuals, Sarah and James, have not only forged a strong personal bond as roommates but have also 
+carved out their distinctive digital presence through their respective webpages, showcasing their varied interests 
+and experiences.
+"""

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
@@ -57,7 +57,7 @@ def authenticate(credentials: HTTPAuthorizationCredentials = Depends(sec)):
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-
+ # TODO: move the logic to a separate file
 async def timely_update_vid_embedding():
     while True:
         try:

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
@@ -120,7 +120,7 @@ def init_rag_ui() -> gr.Interface:
         textbox_array_graph_config = create_configs_block()
 
         with gr.Tab(label="1. Build RAG Index 💡"):
-            textbox_input_schema, textbox_info_extract_template = create_vector_graph_block()
+           textbox_input_text, textbox_input_schema, textbox_info_extract_template = create_vector_graph_block()
         with gr.Tab(label="2. (Graph)RAG & User Functions 📖"):
             (
                 textbox_inp,
@@ -147,6 +147,7 @@ def init_rag_ui() -> gr.Interface:
                 huge_settings.graph_user,
                 huge_settings.graph_pwd,
                 huge_settings.graph_space,
+                prompt.doc_input_text,
                 prompt.graph_schema,
                 prompt.extract_graph_prompt,
                 prompt.default_question,
@@ -155,7 +156,7 @@ def init_rag_ui() -> gr.Interface:
                 prompt.custom_rerank_info,
                 prompt.default_question,
                 huge_settings.graph_name,
-                prompt.gremlin_generate_prompt,
+                prompt.gremlin_generate_prompt
             )
 
         hugegraph_llm_ui.load(  # pylint: disable=E1101
@@ -167,6 +168,7 @@ def init_rag_ui() -> gr.Interface:
                 textbox_array_graph_config[3],
                 textbox_array_graph_config[4],
                 textbox_array_graph_config[5],
+                textbox_input_text,
                 textbox_input_schema,
                 textbox_info_extract_template,
                 textbox_inp,

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
@@ -120,7 +120,7 @@ def init_rag_ui() -> gr.Interface:
         textbox_array_graph_config = create_configs_block()
 
         with gr.Tab(label="1. Build RAG Index 💡"):
-           textbox_input_text, textbox_input_schema, textbox_info_extract_template = create_vector_graph_block()
+            textbox_input_text, textbox_input_schema, textbox_info_extract_template = create_vector_graph_block()
         with gr.Tab(label="2. (Graph)RAG & User Functions 📖"):
             (
                 textbox_inp,

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -138,4 +138,4 @@ def create_vector_graph_block():
     tab_upload_file.select(fn=on_tab_select, inputs=[input_file, input_text], outputs=[input_file, input_text])
     tab_upload_text.select(fn=on_tab_select, inputs=[input_file, input_text], outputs=[input_file, input_text])
 
-    return input_schema, info_extract_template
+    return input_text, input_schema, info_extract_template

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -51,7 +51,7 @@ def create_vector_graph_block():
   to modify it)
   - Specify the name of the HugeGraph graph instance, it will automatically get the schema from it (like 
   **"hugegraph"**)
-- Graph extract head: The user-defined prompt of graph extracting
+- Graph Extract Prompt Header: The user-defined prompt of graph extracting
 - If already exist the graph data, you should click "**Rebuild vid Index**" to update the index
 """
     )
@@ -73,7 +73,7 @@ def create_vector_graph_block():
                 )
         input_schema = gr.Textbox(value=prompt.graph_schema, label="Schema", lines=15, show_copy_button=True)
         info_extract_template = gr.Textbox(
-            value=prompt.extract_graph_prompt, label="Graph extract head", lines=15, show_copy_button=True
+            value=prompt.extract_graph_prompt, label="Graph Extract Prompt Header", lines=15, show_copy_button=True
         )
         out = gr.Code(label="Output", language="json", elem_classes="code-container-edit")
 

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -17,11 +17,9 @@
 
 # pylint: disable=E1101
 
-import os
-
 import gradio as gr
 
-from hugegraph_llm.config import resource_path, prompt
+from hugegraph_llm.config import prompt
 from hugegraph_llm.utils.graph_index_utils import (
     get_graph_index_info,
     clean_all_graph_index,

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -61,10 +61,22 @@ def create_vector_graph_block():
     with gr.Row():
         with gr.Column():
             with gr.Tab("text") as tab_upload_text:
-                input_text = gr.Textbox(value="", label="Doc(s)", lines=20, show_copy_button=True)
+                input_text = gr.Textbox(
+                    value=(
+                        "Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010. "
+                        "James, in his professional life, works as a journalist. Additionally, Sarah is the proud owner of the website "
+                        "www.sarahsplace.com, while James manages his own webpage, though the specific URL is not mentioned here. "
+                        "These two individuals, Sarah and James, have not only forged a strong personal bond as roommates but have also "
+                        "carved out their distinctive digital presence through their respective webpages, showcasing their varied interests "
+                        "and experiences."
+                    ),
+                    label="Doc(s)",
+                    lines=20,
+                    show_copy_button=True
+                )
             with gr.Tab("file") as tab_upload_file:
                 input_file = gr.File(
-                    value=[os.path.join(resource_path, "demo", "test.txt")],
+                    value=None,
                     label="Docs (multi-files can be selected together)",
                     file_count="multiple",
                 )

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -17,9 +17,12 @@
 
 # pylint: disable=E1101
 
+import os
+import yaml
+
 import gradio as gr
 
-from hugegraph_llm.config import prompt
+from hugegraph_llm.config import resource_path, prompt
 from hugegraph_llm.utils.graph_index_utils import (
     get_graph_index_info,
     clean_all_graph_index,
@@ -29,6 +32,7 @@ from hugegraph_llm.utils.graph_index_utils import (
 )
 from hugegraph_llm.utils.vector_index_utils import clean_vector_index, build_vector_index, get_vector_index_info
 
+input_yaml_file_path = os.path.join(resource_path, "demo", "config_input_text.yaml")
 
 def store_prompt(schema, example_prompt):
     # update env variables: schema and example_prompt
@@ -59,15 +63,10 @@ def create_vector_graph_block():
     with gr.Row():
         with gr.Column():
             with gr.Tab("text") as tab_upload_text:
+                with open(input_yaml_file_path, 'r', encoding="utf-8") as file:
+                    config = yaml.safe_load(file)
                 input_text = gr.Textbox(
-                    value=(
-                        "Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010. "
-                        "James, in his professional life, works as a journalist. Additionally, Sarah is the proud owner of the website "
-                        "www.sarahsplace.com, while James manages his own webpage, though the specific URL is not mentioned here. "
-                        "These two individuals, Sarah and James, have not only forged a strong personal bond as roommates but have also "
-                        "carved out their distinctive digital presence through their respective webpages, showcasing their varied interests "
-                        "and experiences."
-                    ),
+                    value=config["text"],
                     label="Doc(s)",
                     lines=20,
                     show_copy_button=True

--- a/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
@@ -25,15 +25,15 @@ class FetchGraphData:
     def __init__(self, graph: PyHugeClient):
         self.graph = graph
 
-    def run(self, context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-        if context is None:
-            context = {}
-        if "num_vertices" not in context:
-            context["num_vertices"] = self.graph.gremlin().exec("g.V().id().count()")["data"]
-        if "num_edges" not in context:
-            context["num_edges"] = self.graph.gremlin().exec("g.E().id().count()")["data"]
-        if "vertices" not in context:
-            context["vertices"] = self.graph.gremlin().exec("g.V().id().limit(10000)")["data"]
-        if "edges" not in context:
-            context["edges"] = self.graph.gremlin().exec("g.E().id().limit(100)")["data"]
-        return context
+    def run(self, graph_summary_info: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        if graph_summary_info is None:
+            graph_summary_info = {}
+        if "num_vertices" not in graph_summary_info:
+            graph_summary_info["num_vertices"] = self.graph.gremlin().exec("g.V().id().count()")["data"]
+        if "num_edges" not in graph_summary_info:
+            graph_summary_info["num_edges"] = self.graph.gremlin().exec("g.E().id().count()")["data"]
+        if "vertices" not in graph_summary_info:
+            graph_summary_info["vertices"] = self.graph.gremlin().exec("g.V().id().limit(10000)")["data"]
+        if "edges" not in graph_summary_info:
+            graph_summary_info["edges"] = self.graph.gremlin().exec("g.E().id().limit(100)")["data"]
+        return graph_summary_info

--- a/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
@@ -29,7 +29,7 @@ class FetchGraphData:
     def run(self, graph_summary: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         if graph_summary is None:
             graph_summary = {}
-            
+
         # TODO: v_limit will influence the vid embedding logic in build_semantic_index.py
         v_limit = 10000
         e_limit = 200

--- a/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
@@ -20,7 +20,6 @@ from typing import Optional, Dict, Any
 import gradio as gr
 
 from pyhugegraph.client import PyHugeClient
-from hugegraph_llm.utils.log import log
 
 
 class FetchGraphData:
@@ -31,7 +30,7 @@ class FetchGraphData:
         limit_vertices = 10000
         limit_edges = 100
         gr.Info(f"Returning a maximum of {limit_vertices} vertices. \n Returning a maximum of {limit_edges} edges.")
-        
+
         if graph_summary_info is None:
             graph_summary_info = {}
         if "num_vertices" not in graph_summary_info:

--- a/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
@@ -17,8 +17,10 @@
 
 
 from typing import Optional, Dict, Any
+import gradio as gr
 
 from pyhugegraph.client import PyHugeClient
+from hugegraph_llm.utils.log import log
 
 
 class FetchGraphData:
@@ -26,6 +28,10 @@ class FetchGraphData:
         self.graph = graph
 
     def run(self, graph_summary_info: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        limit_vertices = 10000
+        limit_edges = 100
+        gr.Info(f"Returning a maximum of {limit_vertices} vertices. \n Returning a maximum of {limit_edges} edges.")
+        
         if graph_summary_info is None:
             graph_summary_info = {}
         if "num_vertices" not in graph_summary_info:
@@ -33,7 +39,7 @@ class FetchGraphData:
         if "num_edges" not in graph_summary_info:
             graph_summary_info["num_edges"] = self.graph.gremlin().exec("g.E().id().count()")["data"]
         if "vertices" not in graph_summary_info:
-            graph_summary_info["vertices"] = self.graph.gremlin().exec("g.V().id().limit(10000)")["data"]
+            graph_summary_info["vertices"] = self.graph.gremlin().exec(f"g.V().id().limit({limit_vertices})")["data"]
         if "edges" not in graph_summary_info:
-            graph_summary_info["edges"] = self.graph.gremlin().exec("g.E().id().limit(100)")["data"]
+            graph_summary_info["edges"] = self.graph.gremlin().exec(f"g.E().id().limit({limit_edges})")["data"]
         return graph_summary_info

--- a/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/fetch_graph_data.py
@@ -28,6 +28,12 @@ class FetchGraphData:
     def run(self, context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         if context is None:
             context = {}
+        if "num_vertices" not in context:
+            context["num_vertices"] = self.graph.gremlin().exec("g.V().id().count()")["data"]
+        if "num_edges" not in context:
+            context["num_edges"] = self.graph.gremlin().exec("g.E().id().count()")["data"]
         if "vertices" not in context:
             context["vertices"] = self.graph.gremlin().exec("g.V().id().limit(10000)")["data"]
+        if "edges" not in context:
+            context["edges"] = self.graph.gremlin().exec("g.E().id().limit(100)")["data"]
         return context

--- a/hugegraph-llm/src/hugegraph_llm/operators/index_op/build_semantic_index.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/index_op/build_semantic_index.py
@@ -34,7 +34,8 @@ class BuildSemanticIndex:
 
     def run(self, context: Dict[str, Any]) -> Dict[str, Any]:
         past_vids = self.vid_index.properties
-        present_vids = context["vertices"]
+        # TODO: We should build vid vector index separately, especially when the vertices may be very large
+        present_vids = context["vertices"] # Warning: data truncated by fetch_graph_data.py
         removed_vids = set(past_vids) - set(present_vids)
         removed_num = self.vid_index.remove(removed_vids)
         added_vids = list(set(present_vids) - set(past_vids))

--- a/hugegraph-llm/src/hugegraph_llm/resources/demo/config_input_text.yaml
+++ b/hugegraph-llm/src/hugegraph_llm/resources/demo/config_input_text.yaml
@@ -1,7 +1,0 @@
-text: |
-    Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010. 
-    James, in his professional life, works as a journalist. Additionally, Sarah is the proud owner of the website 
-    www.sarahsplace.com, while James manages his own webpage, though the specific URL is not mentioned here. 
-    These two individuals, Sarah and James, have not only forged a strong personal bond as roommates but have also 
-    carved out their distinctive digital presence through their respective webpages, showcasing their varied interests 
-    and experiences.

--- a/hugegraph-llm/src/hugegraph_llm/resources/demo/config_input_text.yaml
+++ b/hugegraph-llm/src/hugegraph_llm/resources/demo/config_input_text.yaml
@@ -1,0 +1,7 @@
+text: |
+    Meet Sarah, a 30-year-old attorney, and her roommate, James, whom she's shared a home with since 2010. 
+    James, in his professional life, works as a journalist. Additionally, Sarah is the proud owner of the website 
+    www.sarahsplace.com, while James manages his own webpage, though the specific URL is not mentioned here. 
+    These two individuals, Sarah and James, have not only forged a strong personal bond as roommates but have also 
+    carved out their distinctive digital presence through their respective webpages, showcasing their varied interests 
+    and experiences.

--- a/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
@@ -35,14 +35,14 @@ from ..operators.kg_construction_task import KgBuilder
 
 def get_graph_index_info():
     builder = KgBuilder(LLMs().get_chat_llm(), Embeddings().get_embedding(), get_hg_client())
-    graph_context = builder.fetch_graph_data().run()
+    graph_summary_info = builder.fetch_graph_data().run()
     vector_index = VectorIndex.from_index_file(str(os.path.join(resource_path, huge_settings.graph_name, "graph_vids")))
-    graph_context["vid_index"] = {
+    graph_summary_info["vid_index"] = {
         "embed_dim": vector_index.index.d,
         "num_vectors": vector_index.index.ntotal,
         "num_vids": len(vector_index.properties),
     }
-    return json.dumps(graph_context, ensure_ascii=False, indent=2)
+    return json.dumps(graph_summary_info, ensure_ascii=False, indent=2)
 
 
 def clean_all_graph_index():

--- a/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
@@ -80,8 +80,14 @@ def extract_graph(input_file, input_text, schema, example_prompt) -> str:
 
     try:
         context = builder.run()
-        graph_elements = {"vertices": context["vertices"], "edges": context["edges"]}
-        return json.dumps(graph_elements, ensure_ascii=False, indent=2)
+        if not context["vertices"] and not context["edges"]:
+            log.info("Please check the schema.(The schema may not match the Doc)")
+            return json.dumps(
+                {"vertices": context["vertices"], "edges": context["edges"], "warning": "The schema may not match the Doc"},
+                ensure_ascii=False,
+                indent=2
+            )
+        return json.dumps({"vertices": context["vertices"], "edges": context["edges"]}, ensure_ascii=False, indent=2)
     except Exception as e:  # pylint: disable=broad-exception-caught
         log.error(e)
         raise gr.Error(str(e))

--- a/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
@@ -83,7 +83,11 @@ def extract_graph(input_file, input_text, schema, example_prompt) -> str:
         if not context["vertices"] and not context["edges"]:
             log.info("Please check the schema.(The schema may not match the Doc)")
             return json.dumps(
-                {"vertices": context["vertices"], "edges": context["edges"], "warning": "The schema may not match the Doc"},
+                {
+                    "vertices": context["vertices"],
+                    "edges": context["edges"],
+                    "warning": "The schema may not match the Doc"
+                    },
                 ensure_ascii=False,
                 indent=2
             )

--- a/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
@@ -35,14 +35,14 @@ from ..operators.kg_construction_task import KgBuilder
 
 def get_graph_index_info():
     builder = KgBuilder(LLMs().get_chat_llm(), Embeddings().get_embedding(), get_hg_client())
-    context = builder.fetch_graph_data().run()
+    graph_context = builder.fetch_graph_data().run()
     vector_index = VectorIndex.from_index_file(str(os.path.join(resource_path, huge_settings.graph_name, "graph_vids")))
-    context["vid_index"] = {
+    graph_context["vid_index"] = {
         "embed_dim": vector_index.index.d,
         "num_vectors": vector_index.index.ntotal,
         "num_vids": len(vector_index.properties),
     }
-    return json.dumps(context, ensure_ascii=False, indent=2)
+    return json.dumps(graph_context, ensure_ascii=False, indent=2)
 
 
 def clean_all_graph_index():

--- a/hugegraph-llm/src/hugegraph_llm/utils/vector_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/vector_index_utils.py
@@ -55,7 +55,7 @@ def read_documents(input_file, input_text):
     return texts
 
 
-#pylint disable=C0301
+#pylint: disable=C0301
 def get_vector_index_info():
     chunk_vector_index = VectorIndex.from_index_file(str(os.path.join(resource_path, huge_settings.graph_name, "chunks")))
     graph_vid_vector_index = VectorIndex.from_index_file(str(os.path.join(resource_path, huge_settings.graph_name, "graph_vids")))

--- a/hugegraph-llm/src/hugegraph_llm/utils/vector_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/vector_index_utils.py
@@ -56,11 +56,15 @@ def read_documents(input_file, input_text):
 
 
 def get_vector_index_info():
-    vector_index = VectorIndex.from_index_file(str(os.path.join(resource_path, huge_settings.graph_name, "chunks")))
+    chunk_vector_index = VectorIndex.from_index_file(str(os.path.join(resource_path, huge_settings.graph_name, "chunks")))
+    graph_vid_vector_index = VectorIndex.from_index_file(str(os.path.join(resource_path, huge_settings.graph_name, "graph_vids")))
     return json.dumps({
-        "embed_dim": vector_index.index.d,
-        "num_vectors": vector_index.index.ntotal,
-        "num_properties": len(vector_index.properties)
+        "embed_dim": chunk_vector_index.index.d,
+        "vector_info": {
+            "chunk_vector_num": chunk_vector_index.index.ntotal,
+            "graph_vid_vector_num": graph_vid_vector_index.index.ntotal,
+            "graph_properties_vector_num": len(chunk_vector_index.properties)
+        }
     }, ensure_ascii=False, indent=2)
 
 

--- a/hugegraph-llm/src/hugegraph_llm/utils/vector_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/vector_index_utils.py
@@ -29,7 +29,9 @@ from hugegraph_llm.utils.hugegraph_utils import get_hg_client
 
 
 def read_documents(input_file, input_text):
-    if input_file:
+    if input_text:
+        texts = [input_text]
+    elif input_file:
         texts = []
         for file in input_file:
             full_path = file.name
@@ -48,8 +50,6 @@ def read_documents(input_file, input_text):
                 raise gr.Error("PDF will be supported later! Try to upload text/docx now")
             else:
                 raise gr.Error("Please input txt or docx file.")
-    elif input_text:
-        texts = [input_text]
     else:
         raise gr.Error("Please input text or upload file.")
     return texts

--- a/hugegraph-llm/src/hugegraph_llm/utils/vector_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/vector_index_utils.py
@@ -55,6 +55,7 @@ def read_documents(input_file, input_text):
     return texts
 
 
+#pylint disable=C0301
 def get_vector_index_info():
     chunk_vector_index = VectorIndex.from_index_file(str(os.path.join(resource_path, huge_settings.graph_name, "chunks")))
     graph_vid_vector_index = VectorIndex.from_index_file(str(os.path.join(resource_path, huge_settings.graph_name, "graph_vids")))
@@ -74,6 +75,8 @@ def clean_vector_index():
 
 
 def build_vector_index(input_file, input_text):
+    if input_file and input_text:
+        raise gr.Error("Please only choose one between file and text.")
     texts = read_documents(input_file, input_text)
     builder = KgBuilder(LLMs().get_chat_llm(), Embeddings().get_embedding(), get_hg_client())
     context = builder.chunk_split(texts, "paragraph", "zh").build_vector_index().run()


### PR DESCRIPTION
1. **Modify the return messages of `Get Vector Index Info`** . Display the number of elements in **"chunk vector"** and **"graph vid vector"** separately.
`{
  "embed_dim": 1024,
  "vector_info": {
    "chunk_vector_num": 8,
    "graph_vid_vector_num": 483,
    "graph_properties_vector_num": 8
  }
}`

2. **Modify the return messages of `Get Graph Index Info`** . Display the number of vertices and edges. Display the first 100 edges.
`{
  "num_vertices": [
    483
  ],
  "num_edges": [
    692
  ],
  "vertices": [
    "12:James",
    "12:Sarah"
    ....],
  "edges": [
    "S9:徐起>12>12>>S10:冀RM78Y7!小型轿车!徐起",
    "S9:刘雪峰>11>11>>S11:未与前车保持足以采取紧急制动措施的安全距离",
    ....],
      "vid_index": {
    "embed_dim": 1024,
    "num_vectors": 483,
    "num_vids": 483
  }
}
  `

3. **When a user simultaneously employs text and files, a `log.error` pops up.**

4. add doc_input_text into config_prompt.py to **impl text in Doc(s) persistence**