### PR TITLE
refactor(llm): return schema.groovy first when backup graph data

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/utils/hugegraph_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/hugegraph_utils.py
@@ -124,7 +124,7 @@ def backup_data():
                     json.dump(data, f, ensure_ascii=False)
                 elif filename == "vertices.json":
                     data_full = client.gremlin().exec(query)["data"][0]["vertices"]
-                    data = [{key: value for key, value in vertex.items() if key != "id"} for vertex in data_full] if all_pk_flag else data_full
+                    data = [{key: value for key, value in vertex.items() if key != "id"} for vertex in data_full] if all_pk_flag else data_full #pylint: disable=C0301
                     json.dump(data, f, ensure_ascii=False)
                 elif filename == "schema.json":
                     data_full = query

--- a/hugegraph-llm/src/hugegraph_llm/utils/hugegraph_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/hugegraph_utils.py
@@ -118,23 +118,7 @@ def backup_data():
         all_pk_flag = all(data.get('id_strategy') == 'PRIMARY_KEY' for data in vertexlabels)
 
         for filename, query in files.items():
-            with open(os.path.join(backup_subdir, filename), "w", encoding="utf-8") as f:
-                if filename == "edges.json":
-                    data = client.gremlin().exec(query)["data"][0]["edges"]
-                    json.dump(data, f, ensure_ascii=False)
-                elif filename == "vertices.json":
-                    data_full = client.gremlin().exec(query)["data"][0]["vertices"]
-                    data = [{key: value for key, value in vertex.items() if key != "id"} for vertex in data_full] if all_pk_flag else data_full #pylint: disable=C0301
-                    json.dump(data, f, ensure_ascii=False)
-                elif filename == "schema.json":
-                    data_full = query
-                    if isinstance(data_full, dict) and "schema" in data_full:
-                        groovy_filename = filename.replace(".json", ".groovy")
-                        with open(os.path.join(backup_subdir, groovy_filename), "w", encoding="utf-8") as groovy_file:
-                            groovy_file.write(str(data_full["schema"]))
-                    else:
-                        data = data_full
-                        json.dump(data, f, ensure_ascii=False)
+            write_backup_file(client, backup_subdir, filename, query, all_pk_flag)
 
         log.info("Backup successfully in %s.", backup_subdir)
         relative_backup_subdir = os.path.relpath(backup_subdir, start=resource_path)
@@ -143,6 +127,27 @@ def backup_data():
     except Exception as e:  # pylint: disable=W0718
         log.critical("Backup failed: %s", e, exc_info=True)
         raise Exception("Failed to execute backup") from e
+
+
+def write_backup_file(client, backup_subdir, filename, query, all_pk_flag):
+    with open(os.path.join(backup_subdir, filename), "w", encoding="utf-8") as f:
+        if filename == "edges.json":
+            data = client.gremlin().exec(query)["data"][0]["edges"]
+            json.dump(data, f, ensure_ascii=False)
+        elif filename == "vertices.json":
+            data_full = client.gremlin().exec(query)["data"][0]["vertices"]
+            data = [{key: value for key, value in vertex.items() if key != "id"}
+                    for vertex in data_full] if all_pk_flag else data_full
+            json.dump(data, f, ensure_ascii=False)
+        elif filename == "schema.json":
+            data_full = query
+            if isinstance(data_full, dict) and "schema" in data_full:
+                groovy_filename = filename.replace(".json", ".groovy")
+                with open(os.path.join(backup_subdir, groovy_filename), "w", encoding="utf-8") as groovy_file:
+                    groovy_file.write(str(data_full["schema"]))
+            else:
+                data = data_full
+                json.dump(data, f, ensure_ascii=False)
 
 
 def manage_backup_retention():


### PR DESCRIPTION
**1 file:**
- hugegraph-llm/src/hugegraph_llm/utils/hugegraph_utils.py


**2 points:**
- Modified the format of the backup data (vertices.json, edges.json, and schema.json)
- Automatically select and return either schema.groovy or schema.json