### PR TITLE
chore: add collaborators in asf config

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,11 +17,8 @@
 
 github:
   features:
-    # Enable issue management
     issues: true
-    # Enable wiki for documentation
     wiki: true
-    # Enable projects for project management boards
     projects: true
   description: The integration of HugeGraph with AI/LLM & GraphRAG
   homepage: https://hugegraph.apache.org/docs/quickstart/hugegraph-ai/
@@ -49,6 +46,14 @@ github:
         dismiss_stale_reviews: true
         require_code_owner_reviews: false
         required_approving_review_count: 1
+  # (for non-committer): assign/edit/close issues & PR, without write access to the code
+  collaborators:
+    - ChenZiHong-Gavin
+    - MrJs133
+    - vichayturen
+    - HJ-Young
+    - afterimagex
+    - returnToInnocence
 
 # refer https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Notificationsettingsforrepositories
 notifications:


### PR DESCRIPTION
As title:

could refer https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub