### PR TITLE
refactor: replace the IP + Port with URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,7 +126,7 @@ celerybeat.pid
 *.sage.py
 
 # prompt config
-config_prompt.yaml
+config_prompt.yaml*
 
 # Environments
 .env

--- a/hugegraph-llm/README.md
+++ b/hugegraph-llm/README.md
@@ -8,23 +8,23 @@ This project includes runnable demos, it can also be used as a third-party libra
 As we know, graph systems can help large models address challenges like timeliness and hallucination,
 while large models can help graph systems with cost-related issues.
 
-With this project, we aim to reduce the cost of using graph systems, and decrease the complexity of 
+With this project, we aim to reduce the cost of using graph systems and decrease the complexity of 
 building knowledge graphs. This project will offer more applications and integration solutions for 
 graph systems and large language models.
 1.  Construct knowledge graph by LLM + HugeGraph
 2.  Use natural language to operate graph databases (Gremlin/Cypher)
-3.  Knowledge graph supplements answer context (GraphRAG -> Graph Agent)
+3.  Knowledge graph supplements answer context (GraphRAG → Graph Agent)
 
 ## 2. Environment Requirements
 > [!IMPORTANT]
 > - python 3.10+ (not tested in 3.12)
 > - hugegraph-server 1.3+ (better to use 1.5+)
-> - poetry 2.0+
+> - poetry 2.0+ (`uv` is on the way)
 
 ## 3. Preparation
 
 1. Start the HugeGraph database, you can run it via [Docker](https://hub.docker.com/r/hugegraph/hugegraph)/[Binary Package](https://hugegraph.apache.org/docs/download/download/).  
-    Refer to detailed [doc](https://hugegraph.apache.org/docs/quickstart/hugegraph-server/#31-use-docker-container-convenient-for-testdev) for more guidance
+    Refer to the detailed [doc](https://hugegraph.apache.org/docs/quickstart/hugegraph-server/#31-use-docker-container-convenient-for-testdev) for more guidance
 
 2. Configuring the poetry environment, Use the official installer to install Poetry, See the [poetry documentation](https://poetry.pythonlang.cn/docs/#installing-with-pipx) for other installation methods   
     ```bash
@@ -32,11 +32,11 @@ graph systems and large language models.
     curl -sSL https://install.python-poetry.org | python3 - # install the latest version like 2.0+
     ```
 
-2. Clone this project
+3. Clone this project
     ```bash
     git clone https://github.com/apache/incubator-hugegraph-ai.git
     ```
-3. Install [hugegraph-python-client](../hugegraph-python-client) and [hugegraph_llm](src/hugegraph_llm), poetry officially recommends using virtual environments
+4. Install [hugegraph-python-client](../hugegraph-python-client) and [hugegraph_llm](src/hugegraph_llm), poetry officially recommends using virtual environments
     ```bash
     cd ./incubator-hugegraph-ai/hugegraph-llm
     poetry config --list # List/check the current configuration (Optional)
@@ -48,11 +48,11 @@ graph systems and large language models.
     poetry shell # use 'exit' to leave the shell
     ```  
     If `poetry install` fails or too slow due to network issues, it is recommended to modify `tool.poetry.source` of `hugegraph-llm/pyproject.toml`
-4. Enter the project directory(`./incubator-hugegraph-ai/hugegraph-llm/src`)
+5. Enter the project directory(`./incubator-hugegraph-ai/hugegraph-llm/src`)
     ```bash
     cd ./src
     ```
-5. Start the gradio interactive demo of **Graph RAG**, you can run with the following command, and open http://127.0.0.1:8001 after starting
+6. Start the gradio interactive demo of **Graph RAG**, you can run with the following command and open http://127.0.0.1:8001 after starting
     ```bash
     python -m hugegraph_llm.demo.rag_demo.app  # same as "poetry run xxx"
     ```
@@ -61,23 +61,23 @@ graph systems and large language models.
     python -m hugegraph_llm.demo.rag_demo.app --host 127.0.0.1 --port 18001
     ```
    
-6. After running the web demo, the config file `.env` will be automatically generated at the path `hugegraph-llm/.env`.    Additionally, a prompt-related configuration file `config_prompt.yaml` will also be generated at the path `hugegraph-llm/src/hugegraph_llm/resources/demo/config_prompt.yaml`.
+7. After running the web demo, the config file `.env` will be automatically generated at the path `hugegraph-llm/.env`.    Additionally, a prompt-related configuration file `config_prompt.yaml` will also be generated at the path `hugegraph-llm/src/hugegraph_llm/resources/demo/config_prompt.yaml`.
     You can modify the content on the web page, and it will be automatically saved to the configuration file after the corresponding feature is triggered.  You can also modify the file directly without restarting the web application; refresh the page to load your latest changes.  
     (Optional)To regenerate the config file, you can use `config.generate` with `-u` or `--update`.  
     ```bash
     python -m hugegraph_llm.config.generate --update
     ```
     Note: `Litellm` support multi-LLM provider, refer [litellm.ai](https://docs.litellm.ai/docs/providers) to config it
-7. (__Optional__) You could use 
+8. (__Optional__) You could use 
     [hugegraph-hubble](https://hugegraph.apache.org/docs/quickstart/hugegraph-hubble/#21-use-docker-convenient-for-testdev) 
     to visit the graph data, could run it via [Docker/Docker-Compose](https://hub.docker.com/r/hugegraph/hubble) 
-    for guidance. (Hubble is a graph-analysis dashboard include data loading/schema management/graph traverser/display).
-8. (__Optional__) offline download NLTK stopwords  
+    for guidance. (Hubble is a graph-analysis dashboard that includes data loading/schema management/graph traverser/display).
+9. (__Optional__) offline download NLTK stopwords  
     ```bash
     python ./hugegraph_llm/operators/common_op/nltk_helper.py
     ```
 > [!TIP]   
-> You can also refer our [quick-start](./quick_start.md) doc to understand how to use it & the basic query logic 🚧
+> You can also refer to our [quick-start](./quick_start.md) doc to understand how to use it & the basic query logic 🚧
 
 ## 4 Examples
 
@@ -124,7 +124,7 @@ This can be obtained from the `LLMs` class.
     )
     ```
     ![gradio-config](https://hugegraph.apache.org/docs/images/kg-uml.png)
-2. **Import Schema**: The `import_schema` method is used to import a schema from a source. The source can be a HugeGraph instance, a user-defined schema or an extraction result. The method `print_result` can be chained to print the result.
+2. **Import Schema**: The `import_schema` method is used to import a schema from a source. The source can be a HugeGraph instance, a user-defined schema, or an extraction result. The method `print_result` can be chained to print the result.
     ```python
     # Import schema from a HugeGraph instance
     builder.import_schema(from_hugegraph="xxx").print_result()

--- a/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
@@ -24,7 +24,7 @@ from hugegraph_llm.config import prompt
 
 
 class GraphConfigRequest(BaseModel):
-    url: str = Query('http://127.0.0.1:8080', description="hugegraph client url.")
+    url: str = Query('127.0.0.1:8080', description="hugegraph client url.")
     name: str = Query('hugegraph', description="hugegraph client name.")
     user: str = Query('', description="hugegraph client user.")
     pwd: str = Query('', description="hugegraph client pwd.")
@@ -46,7 +46,7 @@ class RAGRequest(BaseModel):
     topk_return_results: int = Query(20, description="Number of sorted results to return finally.")
     vector_dis_threshold: float = Query(0.9, description="Threshold for vector similarity\
                                          (results greater than this will be ignored).")
-    topk_per_keyword : int = Query(1, description="TopK results returned for each keyword \
+    topk_per_keyword: int = Query(1, description="TopK results returned for each keyword \
                                    extracted from the query, by default only the most similar one is returned.")
     client_config: Optional[GraphConfigRequest] = Query(None, description="hugegraph server config.")
 
@@ -71,10 +71,10 @@ class GraphRAGRequest(BaseModel):
     topk_return_results: int = Query(20, description="Number of sorted results to return finally.")
     vector_dis_threshold: float = Query(0.9, description="Threshold for vector similarity \
                                         (results greater than this will be ignored).")
-    topk_per_keyword : int = Query(1, description="TopK results returned for each keyword extracted\
+    topk_per_keyword: int = Query(1, description="TopK results returned for each keyword extracted\
                                     from the query, by default only the most similar one is returned.")
 
-    client_config : Optional[GraphConfigRequest] = Query(None, description="hugegraph server config.")
+    client_config: Optional[GraphConfigRequest] = Query(None, description="hugegraph server config.")
     get_vertex_only: bool = Query(False, description="return only keywords & vertex (early stop).")
 
     gremlin_tmpl_num: int = Query(
@@ -101,7 +101,9 @@ class LLMConfigRequest(BaseModel):
     # qianfan-wenxin-only properties
     secret_key: str = None
     # ollama-only properties
-    url: str = None
+    # TODO: replace to url later
+    host: str = None
+    port: str = None
 
 
 class RerankerConfigRequest(BaseModel):

--- a/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
@@ -24,8 +24,7 @@ from hugegraph_llm.config import prompt
 
 
 class GraphConfigRequest(BaseModel):
-    ip: str = Query('127.0.0.1', description="hugegraph client ip.")
-    port: str = Query('8080', description="hugegraph client port.")
+    url: str = Query('http://127.0.0.1:8080', description="hugegraph client url.")
     name: str = Query('hugegraph', description="hugegraph client name.")
     user: str = Query('', description="hugegraph client user.")
     pwd: str = Query('', description="hugegraph client pwd.")
@@ -102,8 +101,7 @@ class LLMConfigRequest(BaseModel):
     # qianfan-wenxin-only properties
     secret_key: str = None
     # ollama-only properties
-    host: str = None
-    port: str = None
+    url: str = None
 
 
 class RerankerConfigRequest(BaseModel):

--- a/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
@@ -78,8 +78,7 @@ def rag_http_api(
 
     def set_graph_config(req):
         if req.client_config:
-            huge_settings.graph_ip = req.client_config.ip
-            huge_settings.graph_port = req.client_config.port
+            huge_settings.graph_url = req.client_config.url
             huge_settings.graph_name = req.client_config.name
             huge_settings.graph_user = req.client_config.user
             huge_settings.graph_pwd = req.client_config.pwd
@@ -140,7 +139,7 @@ def rag_http_api(
     @router.post("/config/graph", status_code=status.HTTP_201_CREATED)
     def graph_config_api(req: GraphConfigRequest):
         # Accept status code
-        res = apply_graph_conf(req.ip, req.port, req.name, req.user, req.pwd, req.gs, origin_call="http")
+        res = apply_graph_conf(req.url, req.name, req.user, req.pwd, req.gs, origin_call="http")
         return generate_response(RAGResponse(status_code=res, message="Missing Value"))
 
     # TODO: restructure the implement of llm to three types, like "/config/chat_llm"

--- a/hugegraph-llm/src/hugegraph_llm/config/hugegraph_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/hugegraph_config.py
@@ -22,7 +22,7 @@ from .models import BaseConfig
 class HugeGraphConfig(BaseConfig):
     """HugeGraph settings"""
     # graph server config
-    graph_url: Optional[str] = "http://127.0.0.1:8080"
+    graph_url: Optional[str] = "127.0.0.1:8080"
     graph_name: Optional[str] = "hugegraph"
     graph_user: Optional[str] = "admin"
     graph_pwd: Optional[str] = "xxx"

--- a/hugegraph-llm/src/hugegraph_llm/config/hugegraph_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/hugegraph_config.py
@@ -22,8 +22,7 @@ from .models import BaseConfig
 class HugeGraphConfig(BaseConfig):
     """HugeGraph settings"""
     # graph server config
-    graph_ip: Optional[str] = "127.0.0.1"
-    graph_port: Optional[str] = "8080"
+    graph_url: Optional[str] = "http://127.0.0.1:8080"
     graph_name: Optional[str] = "hugegraph"
     graph_user: Optional[str] = "admin"
     graph_pwd: Optional[str] = "xxx"

--- a/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
@@ -40,7 +40,7 @@ Answer:
 
     custom_rerank_info: str = """"""
 
-    default_question: str = """Tell me about Sarah."""
+    default_question: str = """Who is Sarah ?"""
 
     # Note: Users should modify the prompt(examples) according to the real schema and text (property_graph_extract.py)
     extract_graph_prompt: str = """## Main Task

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
@@ -67,8 +67,8 @@ def init_rag_ui() -> gr.Interface:
         """
         TODO: leave a general idea of the unresolved part
         graph_config_input = textbox_array_graph_config
-         = [settings.graph_ip, settings.graph_port, settings.graph_name, graph_user, settings.graph_pwd, settings.graph_space] 
-        
+         = [settings.graph_url, settings.graph_name, graph_user, settings.graph_pwd, settings.graph_space]
+
         llm_config_input = textbox_array_llm_config
          = if settings.llm_type == openai [settings.openai_api_key, settings.openai_api_base, settings.openai_language_model, settings.openai_max_tokens]
          = else if settings.llm_type == ollama [settings.ollama_host, settings.ollama_port, settings.ollama_language_model, ""]
@@ -111,8 +111,7 @@ def init_rag_ui() -> gr.Interface:
             huge_settings.__init__()  # pylint: disable=C2801
             prompt.ensure_yaml_file_exists()
             return (
-                huge_settings.graph_ip,
-                huge_settings.graph_port,
+                huge_settings.graph_url,
                 huge_settings.graph_name,
                 huge_settings.graph_user,
                 huge_settings.graph_pwd,
@@ -137,7 +136,6 @@ def init_rag_ui() -> gr.Interface:
                 textbox_array_graph_config[2],
                 textbox_array_graph_config[3],
                 textbox_array_graph_config[4],
-                textbox_array_graph_config[5],
                 textbox_input_text,
                 textbox_input_schema,
                 textbox_info_extract_template,

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/configs_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/configs_block.py
@@ -179,6 +179,11 @@ def apply_reranker_config(
 
 
 def apply_graph_config(url, name, user, pwd, gs, origin_call=None) -> int:
+    # Add URL prefix automatically to improve user experience
+    if url and not (url.startswith('http://') or url.startswith('https://')):
+        url = f"http://{url}"
+        log.info("Added 'http://' prefix to URL: %s", url)
+
     huge_settings.graph_url = url
     huge_settings.graph_name = name
     huge_settings.graph_user = user
@@ -248,11 +253,16 @@ def create_configs_block() -> list:
     with gr.Accordion("1. Set up the HugeGraph server.", open=False):
         with gr.Row():
             graph_config_input = [
-                gr.Textbox(value=huge_settings.graph_url, label="url"),
-                gr.Textbox(value=huge_settings.graph_name, label="graph"),
-                gr.Textbox(value=huge_settings.graph_user, label="user"),
-                gr.Textbox(value=huge_settings.graph_pwd, label="pwd", type="password"),
-                gr.Textbox(value=huge_settings.graph_space, label="graphspace(Optional)"),
+                gr.Textbox(value=huge_settings.graph_url, label="url",
+                           info="IP:PORT (e.g. 127.0.0.1:8080) or full URL (e.g. http://127.0.0.1:8080)"),
+                gr.Textbox(value=huge_settings.graph_name, label="graph",
+                           info="The graph name of HugeGraph-Server instance"),
+                gr.Textbox(value=huge_settings.graph_user, label="user",
+                           info="Username for graph server auth"),
+                gr.Textbox(value=huge_settings.graph_pwd, label="pwd", type="password",
+                           info="Password for graph server auth"),
+                gr.Textbox(value=huge_settings.graph_space, label="graphspace (Optional)",
+                           info="Namespace for multi-tenant scenarios (leave empty if not using graphspaces)"),
             ]
         graph_config_button = gr.Button("Apply Configuration")
     graph_config_button.click(apply_graph_config, inputs=graph_config_input)  # pylint: disable=no-member

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/configs_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/configs_block.py
@@ -178,18 +178,17 @@ def apply_reranker_config(
     return status_code
 
 
-def apply_graph_config(ip, port, name, user, pwd, gs, origin_call=None) -> int:
-    huge_settings.graph_ip = ip
-    huge_settings.graph_port = port
+def apply_graph_config(url, name, user, pwd, gs, origin_call=None) -> int:
+    huge_settings.graph_url = url
     huge_settings.graph_name = name
     huge_settings.graph_user = user
     huge_settings.graph_pwd = pwd
     huge_settings.graph_space = gs
     # Test graph connection (Auth)
     if gs and gs.strip():
-        test_url = f"http://{ip}:{port}/graphspaces/{gs}/graphs/{name}/schema"
+        test_url = f"{url}/graphspaces/{gs}/graphs/{name}/schema"
     else:
-        test_url = f"http://{ip}:{port}/graphs/{name}/schema"
+        test_url = f"{url}/graphs/{name}/schema"
     auth = HTTPBasicAuth(user, pwd)
     # for http api return status
     response = test_api_connection(test_url, auth=auth, origin_call=origin_call)
@@ -249,8 +248,7 @@ def create_configs_block() -> list:
     with gr.Accordion("1. Set up the HugeGraph server.", open=False):
         with gr.Row():
             graph_config_input = [
-                gr.Textbox(value=huge_settings.graph_ip, label="ip"),
-                gr.Textbox(value=huge_settings.graph_port, label="port"),
+                gr.Textbox(value=huge_settings.graph_url, label="url"),
                 gr.Textbox(value=huge_settings.graph_name, label="graph"),
                 gr.Textbox(value=huge_settings.graph_user, label="user"),
                 gr.Textbox(value=huge_settings.graph_pwd, label="pwd", type="password"),

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/configs_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/configs_block.py
@@ -184,7 +184,6 @@ def apply_graph_config(url, name, user, pwd, gs, origin_call=None) -> int:
     # Add URL prefix automatically to improve user experience
     if url and not (url.startswith('http://') or url.startswith('https://')):
         url = f"http://{url}"
-        log.info("Added 'http://' prefix to URL: %s", url)
 
     huge_settings.graph_url = url
     huge_settings.graph_name = name

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -163,8 +163,7 @@ async def timely_update_vid_embedding(interval_seconds: int = 3600):
         try:
             # Get the latest configuration values on each iteration
             config = {
-                "ip": huge_settings.graph_ip,
-                "port": huge_settings.graph_port,
+                "url": huge_settings.graph_url,
                 "name": huge_settings.graph_name,
                 "user": huge_settings.graph_user,
                 "pwd": huge_settings.graph_pwd,

--- a/hugegraph-llm/src/hugegraph_llm/indices/graph_index.py
+++ b/hugegraph-llm/src/hugegraph_llm/indices/graph_index.py
@@ -25,14 +25,13 @@ from hugegraph_llm.config import huge_settings
 class GraphIndex:
     def __init__(
             self,
-            graph_ip: Optional[str] = huge_settings.graph_ip,
-            graph_port: Optional[str] = huge_settings.graph_port,
+            graph_url: Optional[str] = huge_settings.graph_url,
             graph_name: Optional[str] = huge_settings.graph_name,
             graph_user: Optional[str] = huge_settings.graph_user,
             graph_pwd: Optional[str] = huge_settings.graph_pwd,
             graph_space: Optional[str] = huge_settings.graph_space,
     ):
-        self.client = PyHugeClient(graph_ip, graph_port, graph_name, graph_user, graph_pwd, graph_space)
+        self.client = PyHugeClient(url=graph_url, graph=graph_name, user=graph_user, pwd=graph_pwd, graphspace=graph_space)
 
     def clear_graph(self):
         self.client.gremlin().exec("g.V().drop()")

--- a/hugegraph-llm/src/hugegraph_llm/indices/graph_index.py
+++ b/hugegraph-llm/src/hugegraph_llm/indices/graph_index.py
@@ -31,7 +31,8 @@ class GraphIndex:
             graph_pwd: Optional[str] = huge_settings.graph_pwd,
             graph_space: Optional[str] = huge_settings.graph_space,
     ):
-        self.client = PyHugeClient(url=graph_url, graph=graph_name, user=graph_user, pwd=graph_pwd, graphspace=graph_space)
+        self.client = PyHugeClient(url=graph_url, graph=graph_name, user=graph_user, pwd=graph_pwd,
+                                   graphspace=graph_space)
 
     def clear_graph(self):
         self.client.gremlin().exec("g.V().drop()")

--- a/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/commit_to_hugegraph.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/commit_to_hugegraph.py
@@ -28,12 +28,11 @@ from pyhugegraph.utils.exceptions import NotFoundError, CreateError
 class Commit2Graph:
     def __init__(self):
         self.client = PyHugeClient(
-            huge_settings.graph_ip,
-            huge_settings.graph_port,
-            huge_settings.graph_name,
-            huge_settings.graph_user,
-            huge_settings.graph_pwd,
-            huge_settings.graph_space,
+            url=huge_settings.graph_url,
+            graph=huge_settings.graph_name,
+            user=huge_settings.graph_user,
+            pwd=huge_settings.graph_pwd,
+            graphspace=huge_settings.graph_space,
         )
         self.schema = self.client.schema()
 

--- a/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/graph_rag_query.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/graph_rag_query.py
@@ -247,13 +247,12 @@ class GraphRAGQuery:
             if isinstance(context.get("graph_client"), PyHugeClient):
                 self._client = context["graph_client"]
             else:
-                ip = context.get("ip") or "localhost"
-                port = context.get("port") or "8080"
+                url = context.get("url") or "http://localhost:8080"
                 graph = context.get("graph") or "hugegraph"
                 user = context.get("user") or "admin"
                 pwd = context.get("pwd") or "admin"
                 gs = context.get("graphspace") or None
-                self._client = PyHugeClient(ip, port, graph, user, pwd, gs)
+                self._client = PyHugeClient(url, graph, user, pwd, gs)
         assert self._client is not None, "No valid graph to search."
 
     def get_vertex_details(self, vertex_ids: List[str]) -> List[Dict[str, Any]]:

--- a/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/graph_rag_query.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/graph_rag_query.py
@@ -88,12 +88,11 @@ class GraphRAGQuery:
         gremlin_prompt: Optional[str] = None,
     ):
         self._client = PyHugeClient(
-            huge_settings.graph_ip,
-            huge_settings.graph_port,
-            huge_settings.graph_name,
-            huge_settings.graph_user,
-            huge_settings.graph_pwd,
-            huge_settings.graph_space,
+            url=huge_settings.graph_url,
+            graph=huge_settings.graph_name,
+            user=huge_settings.graph_user,
+            pwd=huge_settings.graph_pwd,
+            graphspace=huge_settings.graph_space,
         )
         self._max_deep = max_deep
         self._max_items = max_graph_items

--- a/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/schema_manager.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/hugegraph_op/schema_manager.py
@@ -24,12 +24,11 @@ class SchemaManager:
     def __init__(self, graph_name: str):
         self.graph_name = graph_name
         self.client = PyHugeClient(
-            huge_settings.graph_ip,
-            huge_settings.graph_port,
-            self.graph_name,
-            huge_settings.graph_user,
-            huge_settings.graph_pwd,
-            huge_settings.graph_space,
+            url=huge_settings.graph_url,
+            graph=self.graph_name,
+            user=huge_settings.graph_user,
+            pwd=huge_settings.graph_pwd,
+            graphspace=huge_settings.graph_space,
         )
         self.schema = self.client.schema()
 

--- a/hugegraph-llm/src/hugegraph_llm/operators/index_op/semantic_id_query.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/index_op/semantic_id_query.py
@@ -45,12 +45,11 @@ class SemanticIdQuery:
         self.topk_per_keyword = topk_per_keyword
         self.vector_dis_threshold = vector_dis_threshold
         self._client = PyHugeClient(
-            huge_settings.graph_ip,
-            huge_settings.graph_port,
-            huge_settings.graph_name,
-            huge_settings.graph_user,
-            huge_settings.graph_pwd,
-            huge_settings.graph_space,
+            url=huge_settings.graph_url,
+            graph=huge_settings.graph_name,
+            user=huge_settings.graph_user,
+            pwd=huge_settings.graph_pwd,
+            graphspace=huge_settings.graph_space,
         )
 
     def _exact_match_vids(self, keywords: List[str]) -> Tuple[List[str], List[str]]:

--- a/hugegraph-llm/src/hugegraph_llm/utils/hugegraph_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/hugegraph_utils.py
@@ -175,12 +175,12 @@ def manage_backup_retention():
 #TODO: In the path demo/rag_demo/configs_block.py,
 # there is a function test_api_connection that is similar to this function,
 # but it is not straightforward to reuse
-def check_graph_db_connection(ip: str, port: str, name: str, user: str, pwd: str, graph_space: str) -> bool:
+def check_graph_db_connection(url: str, name: str, user: str, pwd: str, graph_space: str) -> bool:
     try:
         if graph_space and graph_space.strip():
-            test_url = f"http://{ip}:{port}/graphspaces/{graph_space}/graphs/{name}/schema"
+            test_url = f"{url}/graphspaces/{graph_space}/graphs/{name}/schema"
         else:
-            test_url = f"http://{ip}:{port}/graphs/{name}/schema"
+            test_url = f"{url}/graphs/{name}/schema"
         auth = HTTPBasicAuth(user, pwd)
         response = requests.get(test_url, timeout=(1.0, 5.0), auth=auth)
         return response.status_code == 200

--- a/hugegraph-llm/src/hugegraph_llm/utils/hugegraph_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/hugegraph_utils.py
@@ -39,12 +39,11 @@ def run_gremlin_query(query, fmt=True):
 
 def get_hg_client():
     return PyHugeClient(
-        huge_settings.graph_ip,
-        huge_settings.graph_port,
-        huge_settings.graph_name,
-        huge_settings.graph_user,
-        huge_settings.graph_pwd,
-        huge_settings.graph_space,
+        url=huge_settings.graph_url,
+        graph=huge_settings.graph_name,
+        user=huge_settings.graph_user,
+        pwd=huge_settings.graph_pwd,
+        graphspace=huge_settings.graph_space,
     )
 
 

--- a/hugegraph-ml/src/hugegraph_ml/data/hugegraph2dgl.py
+++ b/hugegraph-ml/src/hugegraph_ml/data/hugegraph2dgl.py
@@ -32,15 +32,14 @@ import networkx as nx
 class HugeGraph2DGL:
     def __init__(
         self,
-        ip: str = "127.0.0.1",
-        port: str = "8080",
+        url: str = "http://127.0.0.1:8080",
         graph: str = "hugegraph",
         user: str = "",
         pwd: str = "",
         graphspace: Optional[str] = None,
     ):
         self._client: PyHugeClient = PyHugeClient(
-            ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace
+            url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace
         )
         self._graph_germlin: GremlinManager = self._client.gremlin()
 

--- a/hugegraph-ml/src/hugegraph_ml/utils/dgl2hugegraph_utils.py
+++ b/hugegraph-ml/src/hugegraph_ml/utils/dgl2hugegraph_utils.py
@@ -39,21 +39,19 @@ from pyhugegraph.client import PyHugeClient
 MAX_BATCH_NUM = 500
 
 def clear_all_data(
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
     graphspace: Optional[str] = None,
 ):
-    client: PyHugeClient = PyHugeClient(ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace)
+    client: PyHugeClient = PyHugeClient(url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace)
     client.graphs().clear_graph_all_data()
 
 
 def import_graph_from_dgl(
     dataset_name,
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
@@ -70,7 +68,7 @@ def import_graph_from_dgl(
         raise ValueError("dataset not supported")
     graph_dgl = dataset_dgl[0]
 
-    client: PyHugeClient = PyHugeClient(ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace)
+    client: PyHugeClient = PyHugeClient(url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace)
     client_schema: SchemaManager = client.schema()
     client_graph: GraphManager = client.graph()
     # create property schema
@@ -123,8 +121,7 @@ def import_graph_from_dgl(
 
 def import_graphs_from_dgl(
     dataset_name,
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
@@ -139,7 +136,7 @@ def import_graphs_from_dgl(
     else:
         raise ValueError("dataset not supported")
     # hugegraph client
-    client: PyHugeClient = PyHugeClient(ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace)
+    client: PyHugeClient = PyHugeClient(url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace)
     client_schema: SchemaManager = client.schema()
     client_graph: GraphManager = client.graph()
     # define vertexLabel/edgeLabel
@@ -204,8 +201,7 @@ def import_graphs_from_dgl(
 
 def import_hetero_graph_from_dgl(
     dataset_name,
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
@@ -216,7 +212,7 @@ def import_hetero_graph_from_dgl(
         hetero_graph = load_acm_raw()
     else:
         raise ValueError("dataset not supported")
-    client: PyHugeClient = PyHugeClient(ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace)
+    client: PyHugeClient = PyHugeClient(url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace)
     client_schema: SchemaManager = client.schema()
     client_graph: GraphManager = client.graph()
 
@@ -286,8 +282,7 @@ def import_hetero_graph_from_dgl(
 
 def import_hetero_graph_from_dgl_no_feat(
     dataset_name,
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
@@ -301,7 +296,7 @@ def import_hetero_graph_from_dgl_no_feat(
     else:
         raise ValueError("dataset not supported")
     client: PyHugeClient = PyHugeClient(
-        ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace
+        url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace
     )
     client_schema: SchemaManager = client.schema()
     client_graph: GraphManager = client.graph()
@@ -360,8 +355,7 @@ def import_hetero_graph_from_dgl_no_feat(
 
 def import_graph_from_nx(
     dataset_name,
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
@@ -374,7 +368,7 @@ def import_graph_from_nx(
         raise ValueError("dataset not supported")
 
     client: PyHugeClient = PyHugeClient(
-        ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace
+        url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace
     )
     client_schema: SchemaManager = client.schema()
     client_graph: GraphManager = client.graph()
@@ -423,8 +417,7 @@ def import_graph_from_nx(
 
 def import_graph_from_dgl_with_edge_feat(
     dataset_name,
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
@@ -442,7 +435,7 @@ def import_graph_from_dgl_with_edge_feat(
     graph_dgl = dataset_dgl[0]
 
     client: PyHugeClient = PyHugeClient(
-        ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace
+        url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace
     )
     client_schema: SchemaManager = client.schema()
     client_graph: GraphManager = client.graph()
@@ -519,8 +512,7 @@ def import_graph_from_dgl_with_edge_feat(
 
 def import_graph_from_ogb(
     dataset_name,
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
@@ -533,7 +525,7 @@ def import_graph_from_ogb(
     graph_dgl = dataset_dgl[0]
 
     client: PyHugeClient = PyHugeClient(
-        ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace
+        url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace
     )
     client_schema: SchemaManager = client.schema()
     client_graph: GraphManager = client.graph()
@@ -631,8 +623,7 @@ def import_split_edge_from_ogb(
     dataset_name,
     idx_to_vertex_id,
     max_nodes: int,
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
@@ -645,7 +636,7 @@ def import_split_edge_from_ogb(
     split_edges = dataset_dgl.get_edge_split()
 
     client: PyHugeClient = PyHugeClient(
-        ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace
+        url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace
     )
     client_schema: SchemaManager = client.schema()
     client_graph: GraphManager = client.graph()
@@ -768,8 +759,7 @@ def import_split_edge_from_ogb(
 
 def import_hetero_graph_from_dgl_bgnn(
     dataset_name,
-    ip: str = "127.0.0.1",
-    port: str = "8080",
+    url: str = "http://127.0.0.1:8080",
     graph: str = "hugegraph",
     user: str = "",
     pwd: str = "",
@@ -783,7 +773,7 @@ def import_hetero_graph_from_dgl_bgnn(
     else:
         raise ValueError("dataset not supported")
     client: PyHugeClient = PyHugeClient(
-        ip=ip, port=port, graph=graph, user=user, pwd=pwd, graphspace=graphspace
+        url=url, graph=graph, user=user, pwd=pwd, graphspace=graphspace
     )
     client_schema: SchemaManager = client.schema()
     client_graph: GraphManager = client.graph()

--- a/hugegraph-python-client/src/pyhugegraph/client.py
+++ b/hugegraph-python-client/src/pyhugegraph/client.py
@@ -48,15 +48,14 @@ def manager_builder(fn: Callable[[Any, "HGraphSession"], T]) -> Callable[[Any], 
 class PyHugeClient:
     def __init__(
         self,
-        ip: str,
-        port: str, # TODO: port should be int?
+        url: str,
         graph: str,
         user: str,
         pwd: str,
         graphspace: Optional[str] = None,
         timeout: Optional[tuple[float, float]] = None
     ):
-        self.cfg = HGraphConfig(ip, port, user, pwd, graph, graphspace, timeout or (0.5, 15.0))
+        self.cfg = HGraphConfig(url, user, pwd, graph, graphspace, timeout or (0.5, 15.0))
 
     @manager_builder
     def schema(self) -> "SchemaManager":

--- a/hugegraph-python-client/src/pyhugegraph/example/hugegraph_example.py
+++ b/hugegraph-python-client/src/pyhugegraph/example/hugegraph_example.py
@@ -19,7 +19,7 @@ from pyhugegraph.client import PyHugeClient
 
 if __name__ == "__main__":
     client = PyHugeClient(
-        "127.0.0.1", "8080", user="admin", pwd="admin", graph="hugegraph", graphspace=None
+        url="http://127.0.0.1:8080", user="admin", pwd="admin", graph="hugegraph", graphspace=None
     )
 
     """schema"""

--- a/hugegraph-python-client/src/pyhugegraph/example/hugegraph_test.py
+++ b/hugegraph-python-client/src/pyhugegraph/example/hugegraph_test.py
@@ -23,8 +23,7 @@ class HugeGraph:
         self,
         username: str = "default",
         password: str = "default",
-        address: str = "127.0.0.1",
-        port: str = "8081",
+        url: str = "http://127.0.0.1:8081",
         graph: str = "hugegraph",
     ) -> None:
         """Create a new HugeGraph wrapper instance."""
@@ -38,11 +37,10 @@ class HugeGraph:
 
         self.username = username
         self.password = password
-        self.address = address
-        self.port = port
+        self.url = url
         self.graph = graph
         self.client = PyHugeClient(
-            address, port, user=username, pwd=password, graph=graph, graphspace=None
+            url=url, user=username, pwd=password, graph=graph, graphspace=None
         )
         self.schema = ""
 

--- a/hugegraph-python-client/src/pyhugegraph/utils/huge_config.py
+++ b/hugegraph-python-client/src/pyhugegraph/utils/huge_config.py
@@ -27,8 +27,7 @@ from pyhugegraph.utils.log import log
 
 @dataclass
 class HGraphConfig:
-    ip: str
-    port: str
+    url: str
     username: str
     password: str
     graph_name: str
@@ -45,7 +44,7 @@ class HGraphConfig:
         else:
             try:
                 response = requests.get(
-                    f"http://{self.ip}:{self.port}/versions", timeout=0.5
+                    f"{self.url}/versions", timeout=0.5
                 )
                 core = response.json()["versions"]["core"]
                 log.info(  # pylint: disable=logging-fstring-interpolation

--- a/hugegraph-python-client/src/pyhugegraph/utils/huge_config.py
+++ b/hugegraph-python-client/src/pyhugegraph/utils/huge_config.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 import requests
+
 from pyhugegraph.utils.log import log
 
 
@@ -37,6 +38,9 @@ class HGraphConfig:
     version: List[int] = field(default_factory=list)
 
     def __post_init__(self):
+        # Add URL prefix compatibility check
+        if self.url and not self.url.startswith('http'):
+            self.url = f"http://{self.url}"
 
         if self.graphspace and self.graphspace.strip():
             self.gs_supported = True
@@ -58,15 +62,13 @@ class HGraphConfig:
                 if major >= 3:
                     self.graphspace = "DEFAULT"
                     self.gs_supported = True
-                    log.warning(
-                        "graph space is not set, default value 'DEFAULT' will be used."
-                    )
+                    log.warning("graph space is not set, default value 'DEFAULT' will be used.")
 
             except Exception as e:  # pylint: disable=broad-exception-caught
                 try:
                     traceback.print_exception(e)
                     self.gs_supported = False
-                except Exception:   # pylint: disable=broad-exception-caught
+                except Exception:  # pylint: disable=broad-exception-caught
                     exc_type, exc_value, tb = sys.exc_info()
                     traceback.print_exception(exc_type, exc_value, tb)
                     log.warning("Failed to retrieve API version information from the server, reverting to default v1.")

--- a/hugegraph-python-client/src/pyhugegraph/utils/huge_requests.py
+++ b/hugegraph-python-client/src/pyhugegraph/utils/huge_requests.py
@@ -109,7 +109,7 @@ class HGraphSession:
         - The result will be "http://127.0.0.1:8000/graphspaces/default/graphs/test_graph/some/things"
         """
 
-        url = f"http://{self._cfg.ip}:{self._cfg.port}/"
+        url = f"{self._cfg.url}/"
         if self._cfg.gs_supported:
             url = urljoin(
                 url,

--- a/hugegraph-python-client/src/tests/client_utils.py
+++ b/hugegraph-python-client/src/tests/client_utils.py
@@ -19,8 +19,7 @@ from pyhugegraph.client import PyHugeClient
 
 
 class ClientUtils:
-    IP = "127.0.0.1"
-    PORT = "8080"
+    URL = "http://127.0.0.1:8080"
     GRAPH = "hugegraph"
     USERNAME = "admin"
     PASSWORD = "admin"
@@ -29,7 +28,7 @@ class ClientUtils:
 
     def __init__(self):
         self.client = PyHugeClient(
-            self.IP, self.PORT, user=self.USERNAME, pwd=self.PASSWORD, graph=self.GRAPH, graphspace=self.GRAPHSPACE
+            url=self.URL, user=self.USERNAME, pwd=self.PASSWORD, graph=self.GRAPH, graphspace=self.GRAPHSPACE
         )
         assert self.client is not None
 


### PR DESCRIPTION
This pull request refactors multiple modules to replace separate IP and port parameters with a unified URL parameter, addressing issue (fix #191). Key changes include updating configuration classes, client constructors, and example/test files to use "url" consistently, as well as modifying related API endpoints and configuration docs.