### PR TITLE
chore(monitoring): Change QPS -> RPM for timer decorator (#229)

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/operators/graph_rag_task.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/graph_rag_task.py
@@ -31,7 +31,7 @@ from hugegraph_llm.operators.index_op.semantic_id_query import SemanticIdQuery
 from hugegraph_llm.operators.index_op.vector_index_query import VectorIndexQuery
 from hugegraph_llm.operators.llm_op.answer_synthesize import AnswerSynthesize
 from hugegraph_llm.operators.llm_op.keyword_extract import KeywordExtract
-from hugegraph_llm.utils.decorators import log_time, log_operator_time, record_qps
+from hugegraph_llm.utils.decorators import log_time, log_operator_time, record_rpm
 from hugegraph_llm.config import prompt, huge_settings
 
 
@@ -235,7 +235,7 @@ class RAGPipeline:
         return self
 
     @log_time("total time")
-    @record_qps
+    @record_rpm
     def run(self, **kwargs) -> Dict[str, Any]:
         """
         Execute all operators in the pipeline in sequence.

--- a/hugegraph-llm/src/hugegraph_llm/operators/gremlin_generate_task.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/gremlin_generate_task.py
@@ -24,7 +24,7 @@ from hugegraph_llm.operators.hugegraph_op.schema_manager import SchemaManager
 from hugegraph_llm.operators.index_op.build_gremlin_example_index import BuildGremlinExampleIndex
 from hugegraph_llm.operators.index_op.gremlin_example_index_query import GremlinExampleIndexQuery
 from hugegraph_llm.operators.llm_op.gremlin_generate import GremlinGenerateSynthesize
-from hugegraph_llm.utils.decorators import log_time, log_operator_time, record_qps
+from hugegraph_llm.utils.decorators import log_time, log_operator_time, record_rpm
 
 
 class GremlinGenerator:
@@ -69,7 +69,7 @@ class GremlinGenerator:
         return self
 
     @log_time("total time")
-    @record_qps
+    @record_rpm
     def run(self, **kwargs):
         context = kwargs
         for operator in self.operators:

--- a/hugegraph-llm/src/hugegraph_llm/operators/kg_construction_task.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/kg_construction_task.py
@@ -31,7 +31,7 @@ from hugegraph_llm.operators.index_op.build_vector_index import BuildVectorIndex
 from hugegraph_llm.operators.llm_op.disambiguate_data import DisambiguateData
 from hugegraph_llm.operators.llm_op.info_extract import InfoExtract
 from hugegraph_llm.operators.llm_op.property_graph_extract import PropertyGraphExtract
-from hugegraph_llm.utils.decorators import log_time, log_operator_time, record_qps
+from hugegraph_llm.utils.decorators import log_time, log_operator_time, record_rpm
 from pyhugegraph.client import PyHugeClient
 
 
@@ -97,7 +97,7 @@ class KgBuilder:
         return self
 
     @log_time("total time")
-    @record_qps
+    @record_rpm
     def run(self, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         for operator in self.operators:
             context = self._run_operator(operator, context)

--- a/hugegraph-llm/src/hugegraph_llm/utils/decorators.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/decorators.py
@@ -76,18 +76,18 @@ def log_operator_time(func: Callable) -> Callable:
         return result
     return wrapper
 
-
-def record_qps(func: Callable) -> Callable:
+def record_rpm(func: Callable) -> Callable:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         start = time.perf_counter()
         result = func(*args, **kwargs)
         call_count = result.get("call_count", 0)
-        qps = call_count / (time.perf_counter() - start)
-        if qps >= 0.10:
-            log.debug("%s QPS: %.2f/s", args[0].__class__.__name__, qps)
+        elapsed_time = time.perf_counter() - start
+        rpm = (call_count / elapsed_time * 60) if elapsed_time > 0 else 0
+        if rpm >= 6.0:
+            log.debug("%s RPM: %.2f/min", args[0].__class__.__name__, rpm)
         else:
-            log.debug("%s QPS: %f/s", args[0].__class__.__name__, qps)
+            log.debug("%s RPM: %f/min", args[0].__class__.__name__, rpm)
         return result
     return wrapper
 


### PR DESCRIPTION
What did I do:
1. Change the function record_qps to record_rpm, which outputs RPM information instead of qps.
2. Replace the position where record_qps is used with record_rpm to ensure runtime accuracy.
3. Testing: Tested using the example of hugegraph_1lm.demo.rag_demo.app to correctly calculate RPM.
4. Testing: Simulate unexpected situations, such as incorrect configuration items, to ensure that this function does not report errors.