### PR TITLE
feat(llm): support semi-automated generated graph schema

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
@@ -387,3 +387,85 @@ MAX_KEYWORDS: {max_keywords}
 职业道路也很出色。另外，Sarah拥有一个个人网站www.sarahsplace.com，而James也经营着自己的网页，不过这里没有提到具体的网址。这两个人，
 Sarah和James，不仅建立起了深厚的室友情谊，还各自在网络上开辟了自己的一片天地，展示着他们各自丰富多彩的兴趣和经历。
 """
+
+
+    build_schema_few_shot: str = """{
+"vertexlabels": [
+    {
+    "id": 1,
+    "name": "person",
+    "id_strategy": "PRIMARY_KEY",
+    "primary_keys": [
+        "name"
+    ],
+    "properties": [
+        "name",
+        "age",
+        "occupation"
+    ]
+    },
+    {
+    "id": 2,
+    "name": "webpage",
+    "id_strategy": "PRIMARY_KEY",
+    "primary_keys": [
+        "name"
+    ],
+    "properties": [
+        "name",
+        "url"
+    ]
+    }
+],
+"edgelabels": [
+    {
+    "id": 1,
+    "name": "roommate",
+    "source_label": "person",
+    "target_label": "person",
+    "properties": [
+        "date"
+    ]
+    },
+    {
+    "id": 2,
+    "name": "link",
+    "source_label": "webpage",
+    "target_label": "person",
+    "properties": []
+    }
+]
+}
+"""
+
+    query_examples: str = """[
+  {
+    "description": "Property filter: Find all 'person' nodes with age > 30 and return their name and occupation",
+    "gremlin": "g.V().hasLabel('person').has('age', gt(30)).valueMap('name','occupation')"
+  },
+  {
+    "description": "Relationship traversal: Find all roommates of the person named Alice, and return their name and age",
+    "gremlin": "g.V().has('person','name','Alice').out('roommate').valueMap('name','age')"
+  },
+  {
+    "description": "Shortest path: Find the shortest path between Bob and Charlie and show the edge labels along the way",
+    "gremlin": "g.V('Bob').repeat(bothE().otherV()).until(has('name','Charlie')).path().by(label).limit(1)"
+  },
+  {
+    "description": "Subgraph match: Find all friend pairs who both follow the same webpage, and return the names and URL",
+    "gremlin": "g.V().hasLabel('webpage').as('w').in('link').as('p1').in('link').as('p2').where('p1', neq('p2')).select('p1','p2','w').by('name').by('name').by('url')"
+  },
+  {
+    "description": "Aggregation: Count the number of people for each occupation and compute their average age",
+    "gremlin": "g.V().hasLabel('person').group().by('occupation').by(__.values('age').fold()).unfold().project('occupation','count','avgAge').by(select(keys)).by(select(values).count(local)).by(select(values).mean(local))"
+  },
+  {
+    "description": "Time-based filter: Find all nodes created after 2025-01-01 and return their name and created_at",
+    "gremlin": "g.V().has('created_at', gt('2025-01-01T00:00:00')).valueMap('name','created_at')"
+  },
+  {
+    "description": "Top-N query: List top 10 most visited webpages with their URL and visit_count",
+    "gremlin": "g.V().hasLabel('webpage').order().by('visit_count', decr).limit(10).valueMap('url','visit_count')"
+  }
+]
+"""

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/app.py
@@ -90,7 +90,7 @@ def init_rag_ui() -> gr.Interface:
         textbox_array_graph_config = create_configs_block()
 
         with gr.Tab(label="1. Build RAG Index 💡"):
-            textbox_input_text, textbox_input_schema, textbox_info_extract_template = create_vector_graph_block()
+            textbox_input_text, textbox_input_schema, textbox_info_extract_template, textbox_query_example, textbox_few_shot = create_vector_graph_block()
         with gr.Tab(label="2. (Graph)RAG & User Functions 📖"):
             (
                 textbox_inp,
@@ -119,6 +119,8 @@ def init_rag_ui() -> gr.Interface:
                 prompt.doc_input_text,
                 prompt.graph_schema,
                 prompt.extract_graph_prompt,
+                prompt.query_examples,
+                prompt.build_schema_few_shot,
                 prompt.default_question,
                 prompt.answer_prompt,
                 prompt.keywords_extract_prompt,
@@ -139,6 +141,8 @@ def init_rag_ui() -> gr.Interface:
                 textbox_input_text,
                 textbox_input_schema,
                 textbox_info_extract_template,
+                textbox_query_example,
+                textbox_few_shot,
                 textbox_inp,
                 textbox_answer_prompt_input,
                 textbox_keywords_extract_prompt_input,

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -40,13 +40,13 @@ def store_prompt(doc, schema, example_prompt, query_example=None, few_shot=None)
     # update env variables: doc, schema and example_prompt
     if (prompt.doc_input_text != doc or prompt.graph_schema != schema
         or prompt.extract_graph_prompt != example_prompt
-        or prompt.query_example != query_example
-        or prompt.few_shot != few_shot):
+        or prompt.query_examples != query_example
+        or prompt.build_schema_few_shot != few_shot):
         prompt.doc_input_text = doc
         prompt.graph_schema = schema
         prompt.extract_graph_prompt = example_prompt
-        prompt.query_example = query_example
-        prompt.few_shot = few_shot
+        prompt.query_examples = query_example
+        prompt.build_schema_few_shot = few_shot
         prompt.update_yaml_file()
 
 

--- a/hugegraph-llm/src/hugegraph_llm/operators/kg_construction_task.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/kg_construction_task.py
@@ -98,7 +98,7 @@ class KgBuilder:
         return self
 
     def build_schema(self):
-        self.operators.append(SchemaBuilder())
+        self.operators.append(SchemaBuilder(self.llm))
         return self
 
     @log_time("total time")

--- a/hugegraph-llm/src/hugegraph_llm/operators/kg_construction_task.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/kg_construction_task.py
@@ -31,6 +31,7 @@ from hugegraph_llm.operators.index_op.build_vector_index import BuildVectorIndex
 from hugegraph_llm.operators.llm_op.disambiguate_data import DisambiguateData
 from hugegraph_llm.operators.llm_op.info_extract import InfoExtract
 from hugegraph_llm.operators.llm_op.property_graph_extract import PropertyGraphExtract
+from hugegraph_llm.operators.llm_op.schema_build import SchemaBuilder
 from hugegraph_llm.utils.decorators import log_time, log_operator_time, record_rpm
 from pyhugegraph.client import PyHugeClient
 
@@ -94,6 +95,10 @@ class KgBuilder:
 
     def print_result(self):
         self.operators.append(PrintResult())
+        return self
+
+    def build_schema(self):
+        self.operators.append(SchemaBuilder())
         return self
 
     @log_time("total time")

--- a/hugegraph-llm/src/hugegraph_llm/operators/llm_op/schema_build.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/llm_op/schema_build.py
@@ -25,7 +25,7 @@ from hugegraph_llm.models.llms.init_llm import LLMs
 from hugegraph_llm.utils.log import log
 
 
-class BuildSchema:
+class SchemaBuilder:
     """Automated Schema Generator"""
 
     def __init__(
@@ -64,7 +64,7 @@ class BuildSchema:
 
     def _extract_schema(self, response: str) -> Dict[str, Any]:
         # Try to extract JSON from Markdown code block
-        match = re.search(r"```json(.*?)```", response, re.DOTALL)
+        match = re.search(r"```(?:json)?\s*(.*?)```", response, re.DOTALL)
         if match:
             response = match.group(1).strip()
 

--- a/hugegraph-llm/src/hugegraph_llm/operators/llm_op/schema_build.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/llm_op/schema_build.py
@@ -102,13 +102,12 @@ class SchemaBuilder:
         """
         if not isinstance(context, dict):
             raise ValueError("Context must be a dictionary")
-
-        required_fields = ["raw_texts", "query_examples", "few_shot_schema"]
-        for field in required_fields:
-            if field not in context:
-                raise ValueError(f"Context must contain '{field}' field")
-            if not isinstance(context[field], (list, dict)):
-                raise ValueError(f"Context field '{field}' must be a list or dict")
+        if "raw_texts" not in context or not isinstance(context["raw_texts"], list):
+            raise ValueError("'raw_texts' must be a list[str]")
+        if "query_examples" not in context or not isinstance(context["query_examples"], list):
+            raise ValueError("'query_examples' must be a list[dict]")
+        if "few_shot_schema" not in context or not isinstance(context["few_shot_schema"], dict):
+            raise ValueError("'few_shot_schema' must be a dict")
 
         raw_texts = context["raw_texts"]
         query_examples = context["query_examples"]

--- a/hugegraph-llm/src/hugegraph_llm/operators/llm_op/schema_build.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/llm_op/schema_build.py
@@ -127,4 +127,3 @@ class SchemaBuilder:
         schema = self._extract_schema(response)
         log.info("Generated schema: %s", json.dumps(schema, indent=2))
         return schema
-

--- a/hugegraph-llm/src/hugegraph_llm/operators/llm_op/schema_build.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/llm_op/schema_build.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import re
+import asyncio
+from typing import List, Dict, Any, Optional, Union
+
+from hugegraph_llm.models.llms.base import BaseLLM
+from hugegraph_llm.models.llms.init_llm import LLMs
+from hugegraph_llm.utils.log import log
+
+
+class BuildSchema:
+    """Automated Schema Generator"""
+
+    def __init__(
+        self,
+        llm: Optional[BaseLLM] = None,
+        schema_prompt: Optional[str] = None,
+    ):
+        self.llm = llm or LLMs().get_chat_llm() #使用 chat 还是其他的如 extract？
+        self.schema_prompt = schema_prompt or (
+            "You are a Graph Schema generator. Based on the following three parts of content, "
+            "output a Schema JSON that complies with HugeGraph specifications:\n\n"
+            "1. Raw data samples:\n{raw_texts}\n\n"
+            "2. Query examples (description + Gremlin):\n{query_examples}\n\n"
+            "3. Few-Shot Schema examples:\n{few_shot_schema}\n\n"
+            "Please return only the JSON object, without any additional explanations."
+        )
+
+    def _format_raw_texts(self, raw_texts: List[str]) -> str:
+        return "\n".join([f"- {text}" for text in raw_texts])
+
+    def _format_query_examples(self, query_examples: List[Dict[str, str]]) -> str:
+        if not query_examples:
+            return "None"
+        examples = []
+        for example in query_examples:
+            examples.append(
+                f"- description: {example.get('description', '')}\n"
+                f"  gremlin: {example.get('gremlin', '')}"
+            )
+        return "\n".join(examples)
+
+    def _format_few_shot_schema(self, few_shot_schema: Dict[str, Any]) -> str:
+        if not few_shot_schema:
+            return "None"
+        return json.dumps(few_shot_schema, indent=2, ensure_ascii=False)
+
+    def _extract_schema(self, response: str) -> Dict[str, Any]:
+        # Try to extract JSON from Markdown code block
+        match = re.search(r"```json(.*?)```", response, re.DOTALL)
+        if match:
+            response = match.group(1).strip()
+
+        try:
+            return json.loads(response)
+        except json.JSONDecodeError as e:
+            log.error("Failed to parse LLM response as JSON: %s", response)
+            raise RuntimeError(f"Invalid JSON response from LLM: {str(e)}")
+
+    def build_prompt(
+        self,
+        raw_texts: List[str],
+        query_examples: List[Dict[str, str]],
+        few_shot_schema: Dict[str, Any]
+    ) -> str:
+        return self.schema_prompt.format(
+            raw_texts=self._format_raw_texts(raw_texts),
+            query_examples=self._format_query_examples(query_examples),
+            few_shot_schema=self._format_few_shot_schema(few_shot_schema)
+        )
+
+    def run(
+        self,
+        context: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Generate schema from context containing raw_texts, query_examples and few_shot_schema.
+
+        Args:
+            context: Dictionary containing:
+                - raw_texts: List of raw text samples
+                - query_examples: List of query examples (description + Gremlin)
+                - few_shot_schema: Example schema for few-shot learning
+
+        Returns:
+            Generated schema as dictionary
+        """
+        raw_texts = context.get("raw_texts", [])
+        query_examples = context.get("query_examples", [])
+        few_shot_schema = context.get("few_shot_schema", {})
+
+        prompt = self.build_prompt(raw_texts, query_examples, few_shot_schema)
+        log.debug("Schema generation prompt:\n%s", prompt)
+
+        response = self.llm.generate(prompt=prompt)
+        log.debug("LLM response:\n%s", response)
+
+        schema = self._extract_schema(response)
+        log.info("Generated schema: %s", json.dumps(schema, indent=2))
+        return schema
+

--- a/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
@@ -137,3 +137,34 @@ def import_graph_data(data: str, schema: str) -> Union[str, Dict[str, Any]]:
         # Note: can't use gr.Error here
         gr.Warning(str(e) + " Please check the graph data format/type carefully.")
         return data
+
+def build_schema(input_text, query_example, few_shot):
+    builder = KgBuilder(LLMs().get_chat_llm(), Embeddings().get_embedding(), get_hg_client())
+    context = {
+        "raw_texts": [input_text] if input_text else [],
+        "query_examples": [] ,
+        "few_shot_schema": json.loads(few_shot) if few_shot else {}
+    }
+
+    if query_example:
+        try:
+            parsed_examples = json.loads(query_example)
+            # Validate and retain the description and gremlin fields
+            context["query_examples"] = [
+                {
+                    "description": ex.get("description", ""),
+                    "gremlin": ex.get("gremlin", "")
+                }
+                for ex in parsed_examples
+                if isinstance(ex, dict) and "description" in ex and "gremlin" in ex
+            ]
+        except json.JSONDecodeError as e:
+            raise gr.Error(f"Query Examples is not in a valid JSON format:{e}")
+
+    schema = builder.build_schema().run(context)
+    try:
+        formatted_schema = json.dumps(schema, ensure_ascii=False, indent=2)
+        return formatted_schema
+    except Exception as e:
+        log.error(f"Failed to format schema: {e}")
+        return str(schema)

--- a/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
@@ -172,6 +172,6 @@ def build_schema(input_text, query_example, few_shot) :
     try:
         formatted_schema = json.dumps(schema, ensure_ascii=False, indent=2)
         return formatted_schema
-    except Exception as e:
-        log.error(f"Failed to format schema: {e}")
+    except (TypeError, ValueError) as e:
+        log.error("Failed to format schema: %s", e)
         return str(schema)


### PR DESCRIPTION
## Overview
This PR implements a semi‑automated graph schema generation feature. The system collects raw data samples provided by the user, along with user‑provided or default built‑in Query Examples and Few‑Shot templates, sends them to the LLM to generate an initial schema draft for user reference. After users review and adjust the draft in the UI, the final Graph Schema is applied to the HugeGraph instance.

## Main Changes
1. **New Operator: `schema_builder.py`**  
   - Adds `SchemaBuilder` operator responsible for prompt construction, invoking the LLM, and parsing the returned schema JSON.  
2. **Built‑in Prompt Configuration: `prompt_config.py`**  
   - Preloads default Query Examples and Few‑Shot schema templates in `prompt_config.py`; users can directly use these default templates for schema generation.  
3. **UI & Workflow Updates**  
   - Updates files such as `vector_graph_block.py` and `kg_construction_task.py` to add a collapsible "Advanced Schema Options" section in the “Build RAG Index” module for triggering the semi‑automated graph schema generation.  