### PR TITLE
fix(llm): Ollama embedding API usage and config param

### DIFF
--- a/hugegraph-llm/pyproject.toml
+++ b/hugegraph-llm/pyproject.toml
@@ -97,7 +97,7 @@ allow-direct-references = true
 
 [tool.uv.sources]
 hugegraph-python-client = { workspace = true }
-pycgraph = { git = "https://github.com/ChunelFeng/CGraph.git", subdirectory = "python", tag = "v3.2.0", marker = "sys_platform == 'linux'" }
+pycgraph = { git = "https://github.com/ChunelFeng/CGraph.git", subdirectory = "python", tag = "v3.2.0" }
 
 [tool.mypy]
 disable_error_code = ["import-untyped"]

--- a/hugegraph-llm/src/hugegraph_llm/models/embeddings/init_embedding.py
+++ b/hugegraph-llm/src/hugegraph_llm/models/embeddings/init_embedding.py
@@ -38,7 +38,7 @@ def get_embedding(llm_configs: LLMConfig):
         )
     if llm_configs.embedding_type == "ollama/local":
         return OllamaEmbedding(
-            model_name=llm_configs.ollama_embedding_model,
+            model=llm_configs.ollama_embedding_model,
             host=llm_configs.ollama_embedding_host,
             port=llm_configs.ollama_embedding_port,
         )

--- a/hugegraph-llm/src/hugegraph_llm/models/embeddings/ollama.py
+++ b/hugegraph-llm/src/hugegraph_llm/models/embeddings/ollama.py
@@ -43,7 +43,7 @@ class OllamaEmbedding(BaseEmbedding):
 
     def get_text_embedding(self, text: str) -> List[float]:
         """Comment"""
-        return list(self.client.embed(model=self.model, input=text)["embeddings"][0])
+        return list(self.client.embed(model=self.model, input=[text])["embeddings"][0])
 
     def get_texts_embeddings(self, texts: List[str], batch_size: int = 32) -> List[List[float]]:
         """Get embeddings for multiple texts with automatic batch splitting.


### PR DESCRIPTION
Corrects the OllamaEmbedding instantiation to use 'model' instead of 'model_name' and updates the embed API call to pass input as a list, matching the expected Ollama API format. Also removes the Linux-only marker from the pycgraph dependency in pyproject.toml.


WE DO NEED TEST:)