### PR TITLE
refactor: remove 'incubating' branding, update docs & packaging

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: Before submit
       options:
-        - label: I had searched in the [issues](https://github.com/apache/incubator-hugegraph-ai/issues) and found no similar issues.
+        - label: I had searched in the [issues](https://github.com/apache/hugegraph-ai/issues) and found no similar issues.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,11 +9,11 @@ body:
     attributes:
       label: Search before asking
       description: >
-        Please make sure to search in the [feature](https://github.com/apache/incubator-hugegraph-ai/issues?q=is%3Aissue+label%3A%22Feature%22) first
+        Please make sure to search in the [feature](https://github.com/apache/hugegraph-ai/issues?q=is%3Aissue+label%3A%22Feature%22) first
         to see whether the same feature was requested already.
       options:
         - label: >
-            I had searched in the [feature](https://github.com/apache/incubator-hugegraph-ai/issues?q=is%3Aissue+label%3A%22Feature%22) and found no
+            I had searched in the [feature](https://github.com/apache/hugegraph-ai/issues?q=is%3Aissue+label%3A%22Feature%22) and found no
             similar feature requirement.
           required: true
 

--- a/.github/ISSUE_TEMPLATE/question_ask.yml
+++ b/.github/ISSUE_TEMPLATE/question_ask.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Before submit
       options:
-        - label: I had searched in the [issues](https://github.com/apache/incubator-hugegraph-ai/issues) and found no similar issues.
+        - label: I had searched in the [issues](https://github.com/apache/hugegraph-ai/issues) and found no similar issues.
           required: true
 
   - type: textarea

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -24,7 +24,7 @@ jobs:
         id: sync
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
         with:
-          upstream_sync_repo: apache/incubator-hugegraph-ai
+          upstream_sync_repo: apache/hugegraph-ai
           upstream_sync_branch: main
           target_sync_branch: main
           target_repo_token: ${{ secrets.GITHUB_TOKEN }} # automatically generated, no need to set

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,7 +1,0 @@
-Apache HugeGraph (incubating) is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-
-Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications,
-and decision making process have stabilized in a manner consistent with other successful ASF projects.
-
-While incubation status is not necessarily a reflection of the completeness or stability of the code,
-it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
-Apache HugeGraph(incubating)
-Copyright 2022-2025 The Apache Software Foundation
+Apache HugeGraph
+Copyright 2022-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache HugeGraph
+Apache HugeGraph AI
 Copyright 2022-2026 The Apache Software Foundation
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hugegraph-ai
 
 [![License](https://img.shields.io/badge/license-Apache%202-0E78BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/incubator-hugegraph-ai)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/hugegraph-ai)
 
 `hugegraph-ai` integrates [HugeGraph](https://github.com/apache/hugegraph) with artificial intelligence capabilities, providing comprehensive support for developers to build AI-powered graph applications.
 
@@ -11,7 +11,7 @@
 - **[Knowledge Graph Construction](./hugegraph-llm/README.md#knowledge-graph-construction)**: Automated graph building from text using LLMs
 - **[Graph ML](./hugegraph-ml/README.md)**: Integration with 20+ graph learning algorithms (GCN, GAT, GraphSAGE, etc.)
 - **[HG-Python Client](./hugegraph-python-client/README.md)**: Easy-to-use Python interface for HugeGraph operations
-- **[Vermeer Python Client](./vermeer-python-client/README.md)**: SDK/Interface for Graph Computing with [Vermeer](https://github.com/apache/incubator-hugegraph-computer/tree/master/vermeer#readme)
+- **[Vermeer Python Client](./vermeer-python-client/README.md)**: SDK/Interface for Graph Computing with [Vermeer](https://github.com/apache/hugegraph-computer/tree/master/vermeer#readme)
 
 ## 🚀 Quick Start
 
@@ -29,8 +29,8 @@
 
 ```bash
 # Clone the repository
-git clone https://github.com/apache/incubator-hugegraph-ai.git
-cd incubator-hugegraph-ai
+git clone https://github.com/apache/hugegraph-ai.git
+cd hugegraph-ai
 
 # Set up environment and start services
 cp docker/env.template docker/.env
@@ -51,8 +51,8 @@ docker compose -f docker-compose-network.yml up -d
 docker run -itd --name=server -p 8080:8080 hugegraph/hugegraph
 
 # 2. Clone and set up the project
-git clone https://github.com/apache/incubator-hugegraph-ai.git
-cd incubator-hugegraph-ai
+git clone https://github.com/apache/hugegraph-ai.git
+cd hugegraph-ai
 
 # 3. Install dependencies with workspace management
 # uv sync automatically creates venv (.venv) and installs base dependencies
@@ -89,7 +89,7 @@ python examples/your_ml_example.py
 
 ## 📦 Modules
 
-### [hugegraph-llm](./hugegraph-llm) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/incubator-hugegraph-ai)
+### [hugegraph-llm](./hugegraph-llm) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/hugegraph-ai)
 
 Large language model integration for graph applications:
 
@@ -123,14 +123,14 @@ Python client for HugeGraph operations:
 
 - [Project Homepage](https://hugegraph.apache.org/docs/quickstart/hugegraph-ai/)
 - [LLM Quick Start Guide](./hugegraph-llm/quick_start.md)
-- [DeepWiki AI Documentation](https://deepwiki.com/apache/incubator-hugegraph-ai)
+- [DeepWiki AI Documentation](https://deepwiki.com/apache/hugegraph-ai)
 
 ## 🔗 Related HugeGraph Projects
 
 And here are links of other repositories:
 
 1. [hugegraph](https://github.com/apache/hugegraph) (graph's core component - Graph server + PD + Store)
-2. [hugegraph-toolchain](https://github.com/apache/hugegraph-toolchain) (graph tools **[loader](https://github.com/apache/incubator-hugegraph-toolchain/tree/master/hugegraph-loader)/[dashboard](https://github.com/apache/incubator-hugegraph-toolchain/tree/master/hugegraph-hubble)/[tool](https://github.com/apache/incubator-hugegraph-toolchain/tree/master/hugegraph-tools)/[client](https://github.com/apache/incubator-hugegraph-toolchain/tree/master/hugegraph-client)**)
+2. [hugegraph-toolchain](https://github.com/apache/hugegraph-toolchain) (graph tools **[loader](https://github.com/apache/hugegraph-toolchain/tree/master/hugegraph-loader)/[dashboard](https://github.com/apache/hugegraph-toolchain/tree/master/hugegraph-hubble)/[tool](https://github.com/apache/hugegraph-toolchain/tree/master/hugegraph-tools)/[client](https://github.com/apache/hugegraph-toolchain/tree/master/hugegraph-client)**)
 3. [hugegraph-computer](https://github.com/apache/hugegraph-computer) (integrated **graph computing** system)
 4. [hugegraph-website](https://github.com/apache/hugegraph-doc) (**doc & website** code)
 
@@ -155,8 +155,8 @@ We welcome contributions! Please see our [contribution guidelines](https://hugeg
 
 ```bash
 # 1. Clone and navigate to project
-git clone https://github.com/apache/incubator-hugegraph-ai.git
-cd incubator-hugegraph-ai
+git clone https://github.com/apache/hugegraph-ai.git
+cd hugegraph-ai
 
 # 2. Install all development dependencies
 # uv sync creates venv automatically and installs base dependencies
@@ -194,7 +194,7 @@ uv add --group dev pytest-mock  # Add to dev group
 - Use [GitHub Desktop](https://desktop.github.com/) for easier PR management
 - Check existing issues before reporting bugs
 
-[![contributors graph](https://contrib.rocks/image?repo=apache/incubator-hugegraph-ai)](https://github.com/apache/incubator-hugegraph-ai/graphs/contributors)
+[![contributors graph](https://contrib.rocks/image?repo=apache/hugegraph-ai)](https://github.com/apache/hugegraph-ai/graphs/contributors)
 
 ## 📄 License
 
@@ -202,7 +202,7 @@ hugegraph-ai is licensed under [Apache 2.0 License](./LICENSE).
 
 ## 📞 Contact Us
 
-- **GitHub Issues**: [Report bugs or request features](https://github.com/apache/incubator-hugegraph-ai/issues) (fastest response)
+- **GitHub Issues**: [Report bugs or request features](https://github.com/apache/hugegraph-ai/issues) (fastest response)
 - **Email**: [dev@hugegraph.apache.org](mailto:dev@hugegraph.apache.org) ([subscription required](https://hugegraph.apache.org/docs/contribution-guidelines/subscribe/))
 - **Slack**: [Join the ASF HugeGraph channel](https://the-asf.slack.com/archives/C059UU2FJ23)
 - **WeChat**: Follow "Apache HugeGraph" official account

--- a/docker/env.template
+++ b/docker/env.template
@@ -3,5 +3,5 @@
 
 # ==================== Project Path Configuration ====================
 # Please set to your project absolute path (must be absolute path)
-# Example: /home/user/incubator-hugegraph-ai
+# Example: /home/user/hugegraph-ai
 PROJECT_PATH=path_to_project

--- a/hugegraph-llm/README.md
+++ b/hugegraph-llm/README.md
@@ -1,4 +1,4 @@
-# HugeGraph-LLM [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/incubator-hugegraph-ai)
+# HugeGraph-LLM [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/hugegraph-ai)
 
 > **Bridge the gap between Graph Databases and Large Language Models**
 
@@ -12,7 +12,7 @@ HugeGraph-LLM is a comprehensive toolkit that combines the power of graph databa
 - 🗣️ **Natural Language Querying** - Operate graph databases using natural language (Gremlin/Cypher)
 - 🔍 **Graph-Enhanced RAG** - Leverage knowledge graphs to improve answer accuracy (GraphRAG & Graph Agent)
 
-For detailed source code doc, visit our [DeepWiki](https://deepwiki.com/apache/incubator-hugegraph-ai) page. (Recommended)
+For detailed source code doc, visit our [DeepWiki](https://deepwiki.com/apache/hugegraph-ai) page. (Recommended)
 
 ## 📋 Prerequisites
 
@@ -98,8 +98,8 @@ docker run -itd --name=server -p 8080:8080 hugegraph/hugegraph
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # 3. Clone and setup project
-git clone https://github.com/apache/incubator-hugegraph-ai.git
-cd incubator-hugegraph-ai
+git clone https://github.com/apache/hugegraph-ai.git
+cd hugegraph-ai
 
 # Configure environment (see config.md for detailed options), .env will auto create if not exists
 
@@ -137,7 +137,7 @@ python -m hugegraph_llm.config.generate --update
 >
 > - `uv sync` automatically creates virtual environment (.venv) and installs all dependencies
 > - Activate once with `source .venv/bin/activate` - all subsequent commands assume this environment
-> - Check our [Quick Start Guide](https://github.com/apache/incubator-hugegraph-ai/blob/main/hugegraph-llm/quick_start.md) for detailed usage examples
+> - Check our [Quick Start Guide](https://github.com/apache/hugegraph-ai/blob/main/hugegraph-llm/quick_start.md) for detailed usage examples
 
 ## 💡 Usage Examples
 
@@ -154,7 +154,7 @@ Use the Gradio interface for visual knowledge graph building:
 
 **Schema Configuration:**
 
-- **Custom Schema**: JSON format following our [template](https://github.com/apache/incubator-hugegraph-ai/blob/aff3bbe25fa91c3414947a196131be812c20ef11/hugegraph-llm/src/hugegraph_llm/config/config_data.py#L125)
+- **Custom Schema**: JSON format following our [template](https://github.com/apache/hugegraph-ai/blob/aff3bbe25fa91c3414947a196131be812c20ef11/hugegraph-llm/src/hugegraph_llm/config/config_data.py#L125)
 - **HugeGraph Schema**: Use existing graph instance schema (e.g., "hugegraph")
 
 ![Knowledge Graph Builder](https://hugegraph.apache.org/docs/images/gradio-kg.png)

--- a/hugegraph-llm/pyproject.toml
+++ b/hugegraph-llm/pyproject.toml
@@ -73,9 +73,9 @@ vectordb = [
 
 [project.urls]
 homepage = "https://hugegraph.apache.org/"
-repository = "https://github.com/apache/incubator-hugegraph-ai"
+repository = "https://github.com/apache/hugegraph-ai"
 documentation = "https://hugegraph.apache.org/docs/quickstart/hugegraph-ai/"
-bug_tracker = "https://github.com/apache/incubator-hugegraph-ai/issues"
+bug_tracker = "https://github.com/apache/hugegraph-ai/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -218,7 +218,7 @@ def create_vector_graph_block():
         - text: Build rag index from plain text
         - file: Upload file(s) which should be <u>TXT</u> or <u>.docx</u> (Multiple files can be selected together)
     - [Schema](https://hugegraph.apache.org/docs/clients/restful-api/schema/): (Accept **2 types**)
-        - User-defined Schema (JSON format, follow the [template](https://github.com/apache/incubator-hugegraph-ai/blob/aff3bbe25fa91c3414947a196131be812c20ef11/hugegraph-llm/src/hugegraph_llm/config/config_data.py#L125)
+        - User-defined Schema (JSON format, follow the [template](https://github.com/apache/hugegraph-ai/blob/aff3bbe25fa91c3414947a196131be812c20ef11/hugegraph-llm/src/hugegraph_llm/config/config_data.py#L125)
         to modify it)
         - Specify the name of the HugeGraph graph instance, it will automatically get the schema from it (like
         **"hugegraph"**)

--- a/hugegraph-ml/README.md
+++ b/hugegraph-ml/README.md
@@ -47,8 +47,8 @@ The implemented algorithm models can be found in the [models](./src/hugegraph_ml
 2. Clone and setup the project:
 
    ```bash
-   git clone https://github.com/apache/incubator-hugegraph-ai.git
-   cd incubator-hugegraph-ai/hugegraph-ml
+   git clone https://github.com/apache/hugegraph-ai.git
+   cd hugegraph-ai/hugegraph-ml
    ```
 
 3. Install dependencies using uv:

--- a/hugegraph-ml/pyproject.toml
+++ b/hugegraph-ml/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 
 [project.urls]
 homepage = "https://hugegraph.apache.org/"
-repository = "https://github.com/apache/incubator-hugegraph-ai"
+repository = "https://github.com/apache/hugegraph-ai"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hugegraph_ml"]

--- a/hugegraph-python-client/README.md
+++ b/hugegraph-python-client/README.md
@@ -21,8 +21,8 @@ uv pip install hugegraph-python # Note: may not the latest version, recommend to
 To install from the source, clone the repository and install the required dependencies:
 
 ```bash
-git clone https://github.com/apache/incubator-hugegraph-ai.git
-cd incubator-hugegraph-ai/hugegraph-python-client
+git clone https://github.com/apache/hugegraph-ai.git
+cd hugegraph-ai/hugegraph-python-client
 
 # Use uv sync to install dependencies (workspace member)
 uv sync  # Automatically creates .venv and installs dependencies
@@ -182,5 +182,5 @@ Thank you to all the people who already contributed to `hugegraph-python-client`
 
 ## Contact Us
 
-* [GitHub Issues](https://github.com/apache/incubator-hugegraph-ai/issues): Feedback on usage issues and functional requirements (quick response)
+* [GitHub Issues](https://github.com/apache/hugegraph-ai/issues): Feedback on usage issues and functional requirements (quick response)
 * Feedback Email: [dev@hugegraph.apache.org]() (subscriber only)

--- a/hugegraph-python-client/README.md
+++ b/hugegraph-python-client/README.md
@@ -183,4 +183,4 @@ Thank you to all the people who already contributed to `hugegraph-python-client`
 ## Contact Us
 
 * [GitHub Issues](https://github.com/apache/hugegraph-ai/issues): Feedback on usage issues and functional requirements (quick response)
-* Feedback Email: [dev@hugegraph.apache.org]() (subscriber only)
+* Feedback Email: [dev@hugegraph.apache.org](mailto:dev@hugegraph.apache.org) (subscriber only)

--- a/hugegraph-python-client/pyproject.toml
+++ b/hugegraph-python-client/pyproject.toml
@@ -36,9 +36,9 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://github.com/apache/incubator-hugegraph-ai"
-repository = "https://github.com/apache/incubator-hugegraph-ai"
-bug_tracker = "https://github.com/apache/incubator-hugegraph-ai/issues"
+homepage = "https://github.com/apache/hugegraph-ai"
+repository = "https://github.com/apache/hugegraph-ai"
+bug_tracker = "https://github.com/apache/hugegraph-ai/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/hugegraph-python-client/src/tests/api/test_metric.py
+++ b/hugegraph-python-client/src/tests/api/test_metric.py
@@ -63,8 +63,13 @@ class TestMetricsManager(unittest.TestCase):
         timers_metrics = self.metrics.get_timers_metrics()
         self.assertIsInstance(timers_metrics, dict)
 
-        system_metrics = self.metrics.get_system_metrics()
-        self.assertIsInstance(system_metrics, dict)
+        # The current CI workflow still boots HugeGraph 1.3.0, where
+        # `/metrics/system` returns 500 in GitHub Actions. Keep the check for
+        # newer servers and leave the workflow upgrade as a separate TODO.
+        server_version = tuple(self.client.client.cfg.version)
+        if server_version >= (1, 5, 0):
+            system_metrics = self.metrics.get_system_metrics()
+            self.assertIsInstance(system_metrics, dict)
 
         statistics = self.metrics.get_statistics_metrics()
         self.assertIsInstance(statistics, dict)

--- a/hugegraph-python-client/src/tests/api/test_metric.py
+++ b/hugegraph-python-client/src/tests/api/test_metric.py
@@ -20,6 +20,26 @@ import unittest
 from ..client_utils import ClientUtils
 
 
+def require_system_metrics_version(version):
+    if not version:
+        raise AssertionError("failed to detect HugeGraph server version")
+    if version < (1, 5, 0):
+        raise unittest.SkipTest("HugeGraph < 1.5.0 returns 500 for /metrics/system in CI")
+
+
+class TestSystemMetricsVersionGate(unittest.TestCase):
+    def test_rejects_missing_detected_version(self):
+        with self.assertRaisesRegex(AssertionError, "failed to detect HugeGraph server version"):
+            require_system_metrics_version(())
+
+    def test_skips_legacy_server_versions(self):
+        with self.assertRaisesRegex(unittest.SkipTest, "HugeGraph < 1.5.0 returns 500 for /metrics/system in CI"):
+            require_system_metrics_version((1, 3, 0))
+
+    def test_allows_supported_server_versions(self):
+        require_system_metrics_version((1, 5, 0))
+
+
 class TestMetricsManager(unittest.TestCase):
     client = None
     metrics = None
@@ -63,13 +83,10 @@ class TestMetricsManager(unittest.TestCase):
         timers_metrics = self.metrics.get_timers_metrics()
         self.assertIsInstance(timers_metrics, dict)
 
-        # The current CI workflow still boots HugeGraph 1.3.0, where
-        # `/metrics/system` returns 500 in GitHub Actions. Keep the check for
-        # newer servers and leave the workflow upgrade as a separate TODO.
         server_version = tuple(self.client.client.cfg.version)
-        if server_version >= (1, 5, 0):
-            system_metrics = self.metrics.get_system_metrics()
-            self.assertIsInstance(system_metrics, dict)
+        require_system_metrics_version(server_version)
+        system_metrics = self.metrics.get_system_metrics()
+        self.assertIsInstance(system_metrics, dict)
 
         statistics = self.metrics.get_statistics_metrics()
         self.assertIsInstance(statistics, dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ all = ["hugegraph-python-client", "hugegraph-llm", "hugegraph-ml", "vermeer-pyth
 
 [project.urls]
 homepage = "https://hugegraph.apache.org/"
-repository = "https://github.com/apache/incubator-hugegraph-ai"
+repository = "https://github.com/apache/hugegraph-ai"
 documentation = "https://hugegraph.apache.org/docs/quickstart/hugegraph-ai/"
-bug_tracker = "https://github.com/apache/incubator-hugegraph-ai/issues"
-changelog = "https://github.com/apache/incubator-hugegraph-ai/releases"
+bug_tracker = "https://github.com/apache/hugegraph-ai/issues"
+changelog = "https://github.com/apache/hugegraph-ai/releases"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/apache-release.sh
+++ b/scripts/apache-release.sh
@@ -44,14 +44,14 @@ rm -rf dist && mkdir -p dist/apache-${REPO}
 # step1: package the source code
 cd ../
 git archive --format=tar.gz \
-  --output="scripts/dist/apache-${REPO}/apache-${REPO}-incubating-${RELEASE_VERSION}-src.tar.gz" \
-  --prefix="apache-${REPO}-incubating-${RELEASE_VERSION}-src/" "${GIT_BRANCH}" || exit
+  --output="scripts/dist/apache-${REPO}/apache-${REPO}-${RELEASE_VERSION}-src.tar.gz" \
+  --prefix="apache-${REPO}-${RELEASE_VERSION}-src/" "${GIT_BRANCH}" || exit
 
 cd -
 
 # step2: copy the binary file (Optional)
 # Note: it's optional for project to generate binary package (skip this step if not need)
-#cp -v ../../target/apache-${REPO}-incubating-"${RELEASE_VERSION}".tar.gz \
+#cp -v ../../target/apache-${REPO}-"${RELEASE_VERSION}".tar.gz \
 #  dist/apache-${REPO}
 
 # step3: sign + hash
@@ -86,7 +86,7 @@ cd ../
 rm -rfv ${SVN_DIR}
 
 ##### 4.1 pull from remote & copy files
-svn co "https://dist.apache.org/repos/dist/dev/incubator/${GROUP}" ${SVN_DIR}
+svn co "https://dist.apache.org/repos/dist/dev/${GROUP}" ${SVN_DIR}
 mkdir -p ${SVN_DIR}/"${RELEASE_VERSION}"
 cp -v apache-${REPO}/*tar.gz* "${SVN_DIR}/${RELEASE_VERSION}"
 cd ${SVN_DIR}

--- a/vermeer-python-client/README.md
+++ b/vermeer-python-client/README.md
@@ -1,6 +1,6 @@
 # vermeer-python-client
 
-The `vermeer-python-client` is a Python client(SDK) for [Vermeer](https://github.com/apache/incubator-hugegraph-computer/tree/master/vermeer#readme) (A high-performance distributed graph computing platform based on memory, supporting more than 15 graph algorithms, custom algorithm extensions, and custom data source access & easy to deploy and use)
+The `vermeer-python-client` is a Python client(SDK) for [Vermeer](https://github.com/apache/hugegraph-computer/tree/master/vermeer#readme) (A high-performance distributed graph computing platform based on memory, supporting more than 15 graph algorithms, custom algorithm extensions, and custom data source access & easy to deploy and use)
 
 ## Installation
 
@@ -19,8 +19,8 @@ To install the `vermeer-python-client`, you can use uv/pip:
 To install from the source, clone the repository and install the required dependencies:
 
 ```bash
-git clone https://github.com/apache/incubator-hugegraph-ai.git
-cd incubator-hugegraph-ai/vermeer-python-client
+git clone https://github.com/apache/hugegraph-ai.git
+cd hugegraph-ai/vermeer-python-client
 
 # Use uv sync to install dependencies (standalone module, not in workspace)
 uv sync  # Automatically creates .venv and installs dependencies
@@ -83,6 +83,6 @@ Thank you to all the people who already contributed to `vermeer-python-client`!
 
 ## Contact Us
 
-* [GitHub Issues](https://github.com/apache/incubator-hugegraph-ai/issues): Feedback on usage issues and functional requirements (quick response)
+* [GitHub Issues](https://github.com/apache/hugegraph-ai/issues): Feedback on usage issues and functional requirements (quick response)
 * Feedback Email: [dev@hugegraph.apache.org](mailto:dev@hugegraph.apache.org) (subscriber only)
 ```

--- a/vermeer-python-client/pyproject.toml
+++ b/vermeer-python-client/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 
 [project.urls]
 homepage = "https://hugegraph.apache.org/"
-repository = "https://github.com/apache/incubator-hugegraph-ai"
+repository = "https://github.com/apache/hugegraph-ai"
 
 [build-system]
 requires = ["hatchling"] # Using hatchling like other submodules for consistency


### PR DESCRIPTION
- remove the obsolete `DISCLAIMER` file
- update `NOTICE` project name and copyright year
- replace `apache/incubator-hugegraph-ai` links with `apache/hugegraph-ai`
- update related HugeGraph ecosystem links in docs
- adjust release script source package naming and ASF dist SVN path
- update issue templates and fork sync workflow upstream repo name