### PR TITLE
ci: add automatic rerun workflow

### DIFF
--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -1,0 +1,102 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Rerun CI"
+
+on:
+  workflow_run:
+    workflows:
+      - "HG-Python-Client CI"
+      - "HugeGraph-LLM CI"
+    types:
+      - completed
+
+permissions: {}
+
+env:
+  MAX_RERUNS: '2'
+  RETRY_DELAY_SECONDS: '180'
+
+jobs:
+  decide-rerun-action:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    outputs:
+      action: ${{ steps.decision.outputs.action }}
+    steps:
+      - name: Decide rerun action
+        id: decision
+        env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          EVENT_NAME: ${{ github.event.workflow_run.event }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+
+          action="skip"
+          reason="unsupported event: $EVENT_NAME"
+
+          if [[ "$EVENT_NAME" == "push" || "$EVENT_NAME" == "pull_request" ]]; then
+            if (( RUN_ATTEMPT > MAX_RERUNS )); then
+              reason="retry limit reached"
+            else
+              action="rerun"
+              reason="within retry limit"
+            fi
+          fi
+
+          {
+            echo "action=$action"
+            echo "reason=$reason"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Rerun CI decision"
+            echo ""
+            echo "- Workflow: $WORKFLOW_NAME"
+            echo "- Source event: $EVENT_NAME"
+            echo "- Head branch: $HEAD_BRANCH"
+            echo "- Run ID: $RUN_ID"
+            echo "- Current attempt: $RUN_ATTEMPT"
+            echo "- Max automatic reruns: $MAX_RERUNS"
+            echo "- Delay seconds: $RETRY_DELAY_SECONDS"
+            echo "- Action: $action"
+            echo "- Reason: $reason"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  rerun-failed-jobs:
+    needs: decide-rerun-action
+    if: needs.decide-rerun-action.outputs.action == 'rerun'
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait before rerun
+        run: |
+          sleep "$RETRY_DELAY_SECONDS"
+
+      - name: Rerun failed jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh run rerun ${{ github.event.workflow_run.id }} --failed


### PR DESCRIPTION
## Summary

- Add a `Rerun CI` workflow to automatically rerun failed test CI jobs.
- Limit reruns to CI workflows that may be affected by transient integration or service startup issues.
- Keep automatic reruns limited to push and pull request events, with a max retry count of 2.

## Details

This workflow listens to:

- `HG-Python-Client CI`
- `HugeGraph-LLM CI`

It does not rerun deterministic checks such as Ruff, license header checks, or CodeQL.

## Verification

- Verified workflow names against existing GitHub Actions workflow definitions.
- Ran `git diff --check`.
