### PR TITLE
fix: fix the sync action failure

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -15,25 +15,34 @@ jobs:
     if: ${{ github.event.repository.fork }}
 
     steps:
-      # Step 1: run a standard checkout action
       - name: Checkout target repo
         uses: actions/checkout@v4
-
-      # Step 2: run the sync action
-      - name: Sync upstream changes
-        id: sync
-        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
         with:
-          upstream_sync_repo: apache/hugegraph-ai
-          upstream_sync_branch: main
-          target_sync_branch: main
-          target_repo_token: ${{ secrets.GITHUB_TOKEN }} # automatically generated, no need to set
+          fetch-depth: 0
 
-          # Set test_mode true to run tests instead of the true action!!
-          test_mode: false
-
-      - name: Sync check
-        if: failure()
+      - name: Sync upstream changes
         run: |
-          echo "[Error] Due to a change in the workflow file of the upstream repository, GitHub has automatically suspended the scheduled automatic update. You need to manually sync your fork. Please refer to the detailed tutorial for instructions: https://github.com/Yidadaa/ChatGPT-Next-Web#enable-automatic-updates"
-          exit 1
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git remote get-url upstream 2>/dev/null || git remote add upstream https://github.com/apache/hugegraph-ai.git
+          git fetch upstream main
+
+          # Check if upstream changed workflow files
+          WORKFLOW_CHANGED=$(git diff --name-only HEAD upstream/main -- .github/workflows/ | wc -l)
+
+          LOCAL_HEAD=$(git rev-parse HEAD)
+
+          # Merge all upstream changes
+          git merge upstream/main --no-edit
+
+          # If upstream touched workflows, restore our local versions so
+          # GITHUB_TOKEN can push (it is blocked from updating .github/workflows)
+          if [ "$WORKFLOW_CHANGED" -gt 0 ]; then
+            echo "Upstream changed workflow files. Preserving local versions..."
+            git checkout "$LOCAL_HEAD" -- .github/workflows/
+            git add .github/workflows/
+            git diff --cached --quiet || git commit -m "sync: preserve local workflow files"
+          fi
+
+          git push origin main


### PR DESCRIPTION
Purpose                                          
  This PR fixes the sync action failure when upstream modifies workflow files in .github/workflows/.
                                                                                                                                                                                                                                      Previously, Fork-Sync-With-Upstream-action would fail to push with a permission error because GitHub's GITHUB_TOKEN cannot create or update workflow files.
                                                                                                                                                                                                                                    
  Changes         
  - Replace Fork-Sync-With-Upstream-action with a manual git sync script.
  - Check whether upstream modified .github/workflows/ before pushing.
  - Preserve local workflow files when upstream changes them, allowing GITHUB_TOKEN to push the remaining changes.
  - Remove the misleading hardcoded error message and unrelated tutorial link.