### PR TITLE
fix(llm): fix CN prompt output example format to match EN version

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/prompt_config.py
@@ -308,7 +308,7 @@ and experiences.
 {"vertices":[{"vertex_label":"person","properties":["name","age","occupation"]}], "edges":[{"edge_label":"roommate", "source_vertex_label":"person","target_vertex_label":"person","properties":["date"]]}
 
 ### 输出示例：
-[{"id":"1:Sarah","label":"person","type":"vertex","properties":{"name":"Sarah","age":30,"occupation":"律师"}},{"id":"1:James","label":"person","type":"vertex","properties":{"name":"James","occupation":"记者"}},{"label":"roommate","type":"edge","outV":"1:Sarah","outVLabel":"person","inV":"1:James","inVLabel":"person","properties":{"date":"2010"}}]
+{"vertices":[{"id":"1:Sarah","label":"person","type":"vertex","properties":{"name":"Sarah","age":30,"occupation":"律师"}},{"id":"1:James","label":"person","type":"vertex","properties":{"name":"James","occupation":"记者"}}], "edges":[{"id": 1, "label":"roommate","type":"edge","outV":"1:Sarah","outVLabel":"person","inV":"1:James","inVLabel":"person","properties":{"date":"2010"}}]}
 """
 
     gremlin_generate_prompt_CN: str = """


### PR DESCRIPTION
## Summary
- Fix CN property graph extraction prompt output example: change from flat array `[{...}, {...}]` to structured format `{"vertices":[...], "edges":[...]}`
- Add missing `"id"` field in edge example to keep CN/EN consistent

## Problem
The CN prompt (`graph_extract_prompt_CN`) used a flat array format for the output example, while:
- The EN prompt (`graph_extract_prompt_EN`) uses `{"vertices":[...], "edges":[...]}`
- The actual parsing logic in `property_graph_extract.py` expects the structured format

This mismatch could cause LLM to output incorrect JSON structure when processing Chinese text.

## Test plan
- [ ] Verify ruff format and check pass
- [ ] Confirm CN output example now matches EN structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)