### PR TITLE
feat(llm): add optional include_trace to /rag for retrieval debugging

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
@@ -56,6 +56,7 @@ class RAGRequest(BaseModel):
                                    extracted from the query, by default only the most similar one is returned.",
     )
     client_config: Optional[GraphConfigRequest] = Query(None, description="hugegraph server config.")
+    include_trace: bool = Query(False, description="Include retrieval trace/debug info in the response.")
 
     # Keep prompt params in the end
     answer_prompt: Optional[str] = Query(prompt.answer_prompt, description="Prompt to guide the answer generation.")

--- a/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/models/rag_requests.py
@@ -56,7 +56,10 @@ class RAGRequest(BaseModel):
                                    extracted from the query, by default only the most similar one is returned.",
     )
     client_config: Optional[GraphConfigRequest] = Query(None, description="hugegraph server config.")
-    include_trace: bool = Query(False, description="Include retrieval trace/debug info in the response.")
+    include_trace: bool = Query(
+        False,
+        description="Include graph retrieval trace/debug info (graph_only or graph_vector_answer only).",
+    )
 
     # Keep prompt params in the end
     answer_prompt: Optional[str] = Query(prompt.answer_prompt, description="Prompt to guide the answer generation.")

--- a/hugegraph-llm/src/hugegraph_llm/api/models/rag_response.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/models/rag_response.py
@@ -15,9 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel
 
 
 class RAGResponse(BaseModel):
     status_code: int = -1
     message: str = ""
+
+
+class RAGTrace(BaseModel):
+    keywords: Optional[List[Any]] = None
+    match_vids: Optional[List[Any]] = None
+    graph_result_flag: Optional[int] = None
+    gremlin: Optional[str] = None
+    graph_result: Optional[List[Any]] = None
+    vertex_degree_list: Optional[List[Any]] = None
+
+
+def serialize_rag_trace(data: Dict[str, Any]) -> Dict[str, Any]:
+    return RAGTrace(**data).model_dump(exclude_none=True)

--- a/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
@@ -82,6 +82,11 @@ def rag_http_api(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Query must not be empty.",
             )
+        if req.include_trace and not (req.graph_only or req.graph_vector_answer):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="include_trace is only supported for graph_only or graph_vector_answer.",
+            )
 
         result = rag_answer_func(
             text=req.query,

--- a/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
+++ b/hugegraph-llm/src/hugegraph_llm/api/rag_api.py
@@ -28,10 +28,37 @@ from hugegraph_llm.api.models.rag_requests import (
     RAGRequest,
     RerankerConfigRequest,
 )
-from hugegraph_llm.api.models.rag_response import RAGResponse
+from hugegraph_llm.api.models.rag_response import RAGResponse, serialize_rag_trace
 from hugegraph_llm.config import huge_settings, llm_settings, prompt
+from hugegraph_llm.flows.common import GRAPH_TRACE_KEYS
 from hugegraph_llm.utils.graph_index_utils import get_vertex_details
 from hugegraph_llm.utils.log import log
+
+RAG_ANSWER_FIELDS = (
+    ("raw_answer", "raw_answer"),
+    ("vector_only", "vector_only_answer"),
+    ("graph_only", "graph_only_answer"),
+    ("graph_vector_answer", "graph_vector_answer"),
+)
+
+
+def build_rag_api_response(req: RAGRequest, result):
+    response = {"query": req.query}
+    if isinstance(result, dict):
+        for req_key, res_key in RAG_ANSWER_FIELDS:
+            if getattr(req, req_key):
+                response[req_key] = result.get(res_key, "")
+    else:
+        for (req_key, _), value in zip(RAG_ANSWER_FIELDS, result):
+            if getattr(req, req_key):
+                response[req_key] = value
+    if req.include_trace and (req.graph_only or req.graph_vector_answer):
+        raw_trace = result.get("trace") if isinstance(result, dict) else None
+        if raw_trace:
+            trace = serialize_rag_trace(raw_trace)
+            if trace:
+                response["trace"] = trace
+    return response
 
 
 # pylint: disable=too-many-statements
@@ -75,19 +102,9 @@ def rag_http_api(
             answer_prompt=req.answer_prompt or prompt.answer_prompt,
             keywords_extract_prompt=req.keywords_extract_prompt or prompt.keywords_extract_prompt,
             gremlin_prompt=req.gremlin_prompt or prompt.gremlin_generate_prompt,
+            include_trace=req.include_trace,
         )
-        # TODO: we need more info in the response for users to understand the query logic
-        return {
-            "query": req.query,
-            **{
-                key: value
-                for key, value in zip(
-                    ["raw_answer", "vector_only", "graph_only", "graph_vector_answer"],
-                    result,
-                )
-                if getattr(req, key)
-            },
-        }
+        return build_rag_api_response(req, result)
 
     def set_graph_config(req):
         if req.client_config:
@@ -129,16 +146,7 @@ def rag_http_api(
                     result["match_vids"] = vertex_details
 
             if isinstance(result, dict):
-                params = [
-                    "query",
-                    "keywords",
-                    "match_vids",
-                    "graph_result_flag",
-                    "gremlin",
-                    "graph_result",
-                    "vertex_degree_list",
-                ]
-                user_result = {key: result[key] for key in params if key in result}
+                user_result = {key: result[key] for key in GRAPH_TRACE_KEYS if key in result}
                 return {"graph_recall": user_result}
             return {"graph_recall": json.dumps(result)}
 

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/rag_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/rag_block.py
@@ -50,7 +50,7 @@ def rag_answer(
     vector_dis_threshold=0.9,
     topk_per_keyword=1,
     include_trace: bool = False,
-) -> Tuple:
+) -> tuple[str, str, str, str] | dict[str, object]:
     """
     Generate an answer using the RAG (Retrieval-Augmented Generation) pipeline.
     Fetch the Scheduler to deal with the request

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/rag_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/rag_block.py
@@ -49,6 +49,7 @@ def rag_answer(
     topk_return_results=20,
     vector_dis_threshold=0.9,
     topk_per_keyword=1,
+    include_trace: bool = False,
 ) -> Tuple:
     """
     Generate an answer using the RAG (Retrieval-Augmented Generation) pipeline.
@@ -103,9 +104,12 @@ def rag_answer(
             topk_return_results=topk_return_results,
             vector_dis_threshold=vector_dis_threshold,
             topk_per_keyword=topk_per_keyword,
+            include_trace=include_trace,
         )
         if res.get("switch_to_bleu"):
             gr.Warning("Online reranker fails, automatically switches to local bleu rerank.")
+        if include_trace:
+            return res
         return (
             res.get("raw_answer", ""),
             res.get("vector_only_answer", ""),

--- a/hugegraph-llm/src/hugegraph_llm/flows/common.py
+++ b/hugegraph-llm/src/hugegraph_llm/flows/common.py
@@ -19,6 +19,30 @@ from typing import Any, AsyncGenerator, Dict
 from hugegraph_llm.state.ai_state import WkFlowInput
 from hugegraph_llm.utils.log import log
 
+GRAPH_RECALL_TRACE_KEYS = (
+    "keywords",
+    "match_vids",
+    "graph_result_flag",
+    "gremlin",
+    "graph_result",
+    "vertex_degree_list",
+)
+
+GRAPH_TRACE_KEYS = ("query",) + GRAPH_RECALL_TRACE_KEYS
+
+
+def rag_answer_payload(res: Dict[str, Any]) -> Dict[str, str]:
+    return {
+        "raw_answer": res.get("raw_answer", ""),
+        "vector_only_answer": res.get("vector_only_answer", ""),
+        "graph_only_answer": res.get("graph_only_answer", ""),
+        "graph_vector_answer": res.get("graph_vector_answer", ""),
+    }
+
+
+def graph_trace_payload(res: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: res[key] for key in GRAPH_RECALL_TRACE_KEYS if key in res}
+
 
 class BaseFlow(ABC):
     """

--- a/hugegraph-llm/src/hugegraph_llm/flows/rag_flow_graph_only.py
+++ b/hugegraph-llm/src/hugegraph_llm/flows/rag_flow_graph_only.py
@@ -19,7 +19,7 @@ from typing import Literal, Optional, cast
 from pycgraph import GCondition, GPipeline, GRegion
 
 from hugegraph_llm.config import huge_settings, prompt
-from hugegraph_llm.flows.common import BaseFlow
+from hugegraph_llm.flows.common import BaseFlow, graph_trace_payload, rag_answer_payload
 from hugegraph_llm.nodes.common_node.merge_rerank_node import MergeRerankNode
 from hugegraph_llm.nodes.hugegraph_node.graph_query_node import GraphQueryNode
 from hugegraph_llm.nodes.hugegraph_node.schema import SchemaNode
@@ -95,6 +95,7 @@ class RAGGraphOnlyFlow(BaseFlow):
 
         prepared_input.is_graph_rag_recall = is_graph_rag_recall
         prepared_input.is_vector_only = is_vector_only
+        prepared_input.include_trace = kwargs.get("include_trace", False)
         prepared_input.data_json = {
             "query": query,
             "vector_search": vector_search,
@@ -141,13 +142,9 @@ class RAGGraphOnlyFlow(BaseFlow):
             return {"error": "No pipeline provided"}
         res = pipeline.getGParamWithNoEmpty("wkflow_state").to_json()
         log.info("RAGGraphOnlyFlow post processing success")
-        return (
-            {
-                "raw_answer": res.get("raw_answer", ""),
-                "vector_only_answer": res.get("vector_only_answer", ""),
-                "graph_only_answer": res.get("graph_only_answer", ""),
-                "graph_vector_answer": res.get("graph_vector_answer", ""),
-            }
-            if not res.get("is_graph_rag_recall", False)
-            else res
-        )
+        if res.get("is_graph_rag_recall", False):
+            return res
+        out = rag_answer_payload(res)
+        if pipeline.getGParamWithNoEmpty("wkflow_input").include_trace:
+            out["trace"] = graph_trace_payload(res)
+        return out

--- a/hugegraph-llm/src/hugegraph_llm/flows/rag_flow_graph_vector.py
+++ b/hugegraph-llm/src/hugegraph_llm/flows/rag_flow_graph_vector.py
@@ -19,7 +19,7 @@ from typing import Literal, Optional
 from pycgraph import GPipeline
 
 from hugegraph_llm.config import huge_settings, prompt
-from hugegraph_llm.flows.common import BaseFlow
+from hugegraph_llm.flows.common import BaseFlow, graph_trace_payload, rag_answer_payload
 from hugegraph_llm.nodes.common_node.merge_rerank_node import MergeRerankNode
 from hugegraph_llm.nodes.hugegraph_node.graph_query_node import GraphQueryNode
 from hugegraph_llm.nodes.hugegraph_node.schema import SchemaNode
@@ -81,6 +81,7 @@ class RAGGraphVectorFlow(BaseFlow):
         prepared_input.answer_prompt = answer_prompt or prompt.answer_prompt
         prepared_input.custom_related_information = custom_related_information
         prepared_input.schema = huge_settings.graph_name
+        prepared_input.include_trace = kwargs.get("include_trace", False)
 
         prepared_input.data_json = {
             "query": query,
@@ -121,9 +122,7 @@ class RAGGraphVectorFlow(BaseFlow):
             return {"error": "No pipeline provided"}
         res = pipeline.getGParamWithNoEmpty("wkflow_state").to_json()
         log.info("RAGGraphVectorFlow post processing success")
-        return {
-            "raw_answer": res.get("raw_answer", ""),
-            "vector_only_answer": res.get("vector_only_answer", ""),
-            "graph_only_answer": res.get("graph_only_answer", ""),
-            "graph_vector_answer": res.get("graph_vector_answer", ""),
-        }
+        out = rag_answer_payload(res)
+        if pipeline.getGParamWithNoEmpty("wkflow_input").include_trace:
+            out["trace"] = graph_trace_payload(res)
+        return out

--- a/hugegraph-llm/src/hugegraph_llm/state/ai_state.py
+++ b/hugegraph-llm/src/hugegraph_llm/state/ai_state.py
@@ -187,6 +187,7 @@ class WkFlowState(GParam):
     stream_generator: Optional[AsyncGenerator] = None
 
     graph_result_flag: Optional[int] = None
+    gremlin: Optional[str] = None
     vertex_degree_list: Optional[List] = None
     knowledge_with_degree: Optional[Dict] = None
     graph_context_head: Optional[str] = None
@@ -245,6 +246,7 @@ class WkFlowState(GParam):
 
         self.stream_generator = None
         self.graph_result_flag = None
+        self.gremlin = None
         self.vertex_degree_list = None
         self.knowledge_with_degree = None
         self.graph_context_head = None

--- a/hugegraph-llm/src/hugegraph_llm/state/ai_state.py
+++ b/hugegraph-llm/src/hugegraph_llm/state/ai_state.py
@@ -76,6 +76,7 @@ class WkFlowInput(GParam):
     # used for rag_recall api
     is_graph_rag_recall: bool = False
     is_vector_only: bool = False
+    include_trace: bool = False
 
     # used for build text2gremin index
     examples: Optional[List[Dict[str, str]]] = None
@@ -132,6 +133,7 @@ class WkFlowInput(GParam):
         self.examples = None
         self.is_graph_rag_recall = False
         self.is_vector_only = False
+        self.include_trace = False
 
 
 class WkFlowState(GParam):

--- a/hugegraph-llm/src/tests/api/test_rag_api.py
+++ b/hugegraph-llm/src/tests/api/test_rag_api.py
@@ -148,15 +148,16 @@ def test_rag_include_trace_returns_graph_debug_fields_for_graph_vector_answer():
     assert body["trace"]["gremlin"] == "g.V()"
 
 
-def test_rag_include_trace_skipped_for_vector_only():
+def test_rag_include_trace_rejects_vector_only():
     rag_answer = Mock(return_value=("", "vector answer", "", ""))
     response = _rag_client(rag_answer).post(
         "/rag",
         json={"query": "hello", "graph_only": False, "vector_only": True, "include_trace": True},
     )
 
-    assert response.status_code == status.HTTP_200_OK
-    assert "trace" not in response.json()
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "include_trace" in response.json()["detail"]
+    rag_answer.assert_not_called()
 
 
 def test_graph_trace_payload_excludes_prompts_and_secrets():
@@ -183,12 +184,18 @@ def test_build_rag_api_response_supports_legacy_tuple():
     assert response == {"query": "hello", "graph_only": "graph answer"}
 
 
+def test_wkflow_state_assign_from_json_preserves_gremlin():
+    state = WkFlowState()
+    state.assign_from_json({"gremlin": "g.V()"})
+    assert state.gremlin == "g.V()"
+    assert graph_trace_payload(state.to_json())["gremlin"] == "g.V()"
+
+
 def test_rag_graph_only_post_deal_include_trace():
     pipeline = Mock()
     state = WkFlowState()
     state.graph_only_answer = "answer"
-    state.keywords = ["kw"]
-    state.gremlin = "g.V()"
+    state.assign_from_json({"keywords": ["kw"], "gremlin": "g.V()"})
     wk_input = WkFlowInput()
     wk_input.include_trace = True
 

--- a/hugegraph-llm/src/tests/api/test_rag_api.py
+++ b/hugegraph-llm/src/tests/api/test_rag_api.py
@@ -20,7 +20,30 @@ from unittest.mock import Mock
 from fastapi import APIRouter, FastAPI, status
 from fastapi.testclient import TestClient
 
-from hugegraph_llm.api.rag_api import rag_http_api
+from hugegraph_llm.api.models.rag_requests import RAGRequest
+from hugegraph_llm.api.models.rag_response import RAGTrace, serialize_rag_trace
+from hugegraph_llm.api.rag_api import build_rag_api_response, rag_http_api
+from hugegraph_llm.flows.common import graph_trace_payload
+from hugegraph_llm.flows.rag_flow_graph_only import RAGGraphOnlyFlow
+from hugegraph_llm.flows.rag_flow_graph_vector import RAGGraphVectorFlow
+from hugegraph_llm.state.ai_state import WkFlowInput, WkFlowState
+
+
+def _rag_client(rag_answer_func):
+    router = APIRouter()
+    rag_http_api(
+        router,
+        rag_answer_func=rag_answer_func,
+        graph_rag_recall_func=Mock(),
+        apply_graph_conf=Mock(),
+        apply_llm_conf=Mock(),
+        apply_embedding_conf=Mock(),
+        apply_reranker_conf=Mock(),
+        gremlin_generate_selective_func=Mock(),
+    )
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
 
 
 def test_graph_config_api_passes_graph_field_to_apply_graph_conf():
@@ -60,3 +83,141 @@ def test_graph_config_api_passes_graph_field_to_apply_graph_conf():
         "space_a",
         origin_call="http",
     )
+
+
+def test_rag_default_response_has_no_trace():
+    rag_answer = Mock(return_value=("", "", "graph answer", ""))
+    response = _rag_client(rag_answer).post("/rag", json={"query": "hello", "graph_only": True})
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body == {"query": "hello", "graph_only": "graph answer"}
+    assert "trace" not in body
+
+
+def test_rag_include_trace_returns_graph_debug_fields():
+    rag_answer = Mock(
+        return_value={
+            "graph_only_answer": "graph answer",
+            "trace": {
+                "keywords": ["hello"],
+                "match_vids": ["1:foo"],
+                "gremlin": "g.V()",
+            },
+        }
+    )
+    response = _rag_client(rag_answer).post(
+        "/rag",
+        json={"query": "hello", "graph_only": True, "include_trace": True},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["graph_only"] == "graph answer"
+    assert body["trace"]["keywords"] == ["hello"]
+    assert body["trace"]["match_vids"] == ["1:foo"]
+    rag_answer.assert_called_once()
+    assert rag_answer.call_args.kwargs["include_trace"] is True
+
+
+def test_rag_include_trace_returns_graph_debug_fields_for_graph_vector_answer():
+    rag_answer = Mock(
+        return_value={
+            "graph_vector_answer": "hybrid answer",
+            "trace": {
+                "keywords": ["hello"],
+                "match_vids": ["1:foo"],
+                "gremlin": "g.V()",
+            },
+        }
+    )
+    response = _rag_client(rag_answer).post(
+        "/rag",
+        json={
+            "query": "hello",
+            "graph_only": False,
+            "graph_vector_answer": True,
+            "include_trace": True,
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["graph_vector_answer"] == "hybrid answer"
+    assert body["trace"]["keywords"] == ["hello"]
+    assert body["trace"]["gremlin"] == "g.V()"
+
+
+def test_rag_include_trace_skipped_for_vector_only():
+    rag_answer = Mock(return_value=("", "vector answer", "", ""))
+    response = _rag_client(rag_answer).post(
+        "/rag",
+        json={"query": "hello", "graph_only": False, "vector_only": True, "include_trace": True},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "trace" not in response.json()
+
+
+def test_graph_trace_payload_excludes_prompts_and_secrets():
+    trace = graph_trace_payload(
+        {
+            "keywords": ["a"],
+            "gremlin": "g.V()",
+            "answer_prompt": "secret prompt",
+            "graph_pwd": "secret",
+        }
+    )
+    assert trace == {"keywords": ["a"], "gremlin": "g.V()"}
+
+
+def test_serialize_rag_trace_omits_none_fields():
+    trace = serialize_rag_trace({"keywords": ["a"], "gremlin": None})
+    assert trace == {"keywords": ["a"]}
+    assert RAGTrace(**trace).keywords == ["a"]
+
+
+def test_build_rag_api_response_supports_legacy_tuple():
+    req = RAGRequest(query="hello", graph_only=True)
+    response = build_rag_api_response(req, ("", "", "graph answer", ""))
+    assert response == {"query": "hello", "graph_only": "graph answer"}
+
+
+def test_rag_graph_only_post_deal_include_trace():
+    pipeline = Mock()
+    state = WkFlowState()
+    state.graph_only_answer = "answer"
+    state.keywords = ["kw"]
+    state.gremlin = "g.V()"
+    wk_input = WkFlowInput()
+    wk_input.include_trace = True
+
+    def get_param(name):
+        return wk_input if name == "wkflow_input" else state
+
+    pipeline.getGParamWithNoEmpty.side_effect = get_param
+
+    result = RAGGraphOnlyFlow().post_deal(pipeline)
+    assert result["graph_only_answer"] == "answer"
+    assert result["trace"]["keywords"] == ["kw"]
+    assert result["trace"]["gremlin"] == "g.V()"
+
+
+def test_rag_graph_vector_post_deal_include_trace():
+    pipeline = Mock()
+    state = WkFlowState()
+    state.graph_vector_answer = "hybrid answer"
+    state.keywords = ["kw"]
+    state.match_vids = ["1:foo"]
+    wk_input = WkFlowInput()
+    wk_input.include_trace = True
+
+    def get_param(name):
+        return wk_input if name == "wkflow_input" else state
+
+    pipeline.getGParamWithNoEmpty.side_effect = get_param
+
+    result = RAGGraphVectorFlow().post_deal(pipeline)
+    assert result["graph_vector_answer"] == "hybrid answer"
+    assert result["trace"]["keywords"] == ["kw"]
+    assert result["trace"]["match_vids"] == ["1:foo"]


### PR DESCRIPTION
## Summary
 
Closes #347
 
- Adds opt-in `include_trace` on `POST /rag` for graph retrieval debugging.
- Default `/rag` response is unchanged (no trace unless requested).
- Vector/rerank trace deferred to follow-up, per the issue scope.
## What changed
 
| Area | Change |
| --- | --- |
| `RAGRequest` | New field `include_trace: bool = False` |
| `RAGTrace` | Typed model with 6 graph-recall fields (same names as `/rag/graph`, minus `query`) |
| Flows | `RAGGraphOnlyFlow` / `RAGGraphVectorFlow` copy allowlisted fields from `WkFlowState` when trace is enabled |
| `flows/common.py` | `GRAPH_RECALL_TRACE_KEYS` (6) for `/rag` trace; `GRAPH_TRACE_KEYS` (7, incl. `query`) for `/rag/graph` |
| `rag_api.py` | Builds response via `serialize_rag_trace()` (`exclude_none=True`); attaches `trace` only for `graph_only` or `graph_vector_answer` |
| `rag_block.py` | Passes `include_trace` through the scheduler (Gradio UI unchanged) |
 
## Behavior
 
- `include_trace=false` -> same as before: `query` + answer field(s).
- `include_trace=true` + graph mode -> adds `trace` with e.g. `keywords`, `match_vids`, `gremlin`, `graph_result`, etc.
- `vector_only` / `raw_answer` only -> no trace.
- Secrets and prompts are excluded via the allowlist (not a full state dump).
- Missing trace fields are omitted; empty lists are kept when recall ran but matched nothing, so clients can distinguish "didn't run" from "ran, no matches."
## Test plan
 
- [x] Default `/rag` - no trace, same shape
- [x] `include_trace=true` + `graph_only` - trace returned
- [x] `include_trace=true` + `graph_vector_answer` - trace returned
- [x] `include_trace=true` + `vector_only` only - no trace
- [x] Allowlist excludes prompts/secrets
- [x] `RAGGraphOnlyFlow` / `RAGGraphVectorFlow` `post_deal` populate trace
- [x] `serialize_rag_trace` omits `None` fields

```bash
cd hugegraph-llm
SKIP_EXTERNAL_SERVICES=true uv run pytest src/tests/api/test_rag_api.py -v --tb=short
```