### PR TITLE
feat(llm): make graph extraction split configurable

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/config/models/base_prompt_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/models/base_prompt_config.py
@@ -78,6 +78,7 @@ class BasePromptConfig:
     text2gql_graph_schema: str = ""
     gremlin_generate_prompt: str = ""
     doc_input_text: str = ""
+    graph_extract_split_type: str = "document"
     _language_generated: str = ""
     generate_extract_prompt_template: str = ""
 
@@ -136,6 +137,7 @@ class BasePromptConfig:
             "keywords_extract_prompt": to_literal(self.keywords_extract_prompt),
             "gremlin_generate_prompt": to_literal(self.gremlin_generate_prompt),
             "doc_input_text": to_literal(self.doc_input_text),
+            "graph_extract_split_type": to_literal(self.graph_extract_split_type),
             "_language_generated": str(self.llm_settings.language).lower().strip(),
             "generate_extract_prompt_template": to_literal(self.generate_extract_prompt_template),
         }

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -44,12 +44,17 @@ from hugegraph_llm.utils.vector_index_utils import (
 )
 
 
-def store_prompt(doc, schema, example_prompt):
-    # update env variables: doc, schema and example_prompt
-    if prompt.doc_input_text != doc or prompt.graph_schema != schema or prompt.extract_graph_prompt != example_prompt:
+def store_prompt(doc, schema, example_prompt, graph_extract_split_type="document"):
+    if (
+        prompt.doc_input_text != doc
+        or prompt.graph_schema != schema
+        or prompt.extract_graph_prompt != example_prompt
+        or prompt.graph_extract_split_type != graph_extract_split_type
+    ):
         prompt.doc_input_text = doc
         prompt.graph_schema = schema
         prompt.extract_graph_prompt = example_prompt
+        prompt.graph_extract_split_type = graph_extract_split_type
         prompt.update_yaml_file()
 
 
@@ -272,7 +277,7 @@ def create_vector_graph_block():
             vector_import_bt = gr.Button("Import into Vector", variant="primary")
             graph_split_type = gr.Dropdown(
                 choices=["document", "paragraph", "sentence"],
-                value="document",
+                value=prompt.graph_extract_split_type,
                 label="Graph Extraction Split Type",
                 info=("document keeps the current behavior; paragraph/sentence split long docs before extraction."),
             )
@@ -306,31 +311,31 @@ def create_vector_graph_block():
 
         vector_index_btn0.click(get_vector_index_info, outputs=out).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template],
+            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
         )
         vector_index_btn1.click(clean_vector_index).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template],
+            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
         )
         vector_import_bt.click(build_vector_index, inputs=[input_file, input_text], outputs=out).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template],
+            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
         )
         graph_index_btn0.click(get_graph_index_info, outputs=out).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template],
+            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
         )
         graph_index_btn1.click(clean_all_graph_index).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template],
+            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
         )
         graph_data_btn0.click(clean_all_graph_data).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template],
+            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
         )
         graph_index_rebuild_bt.click(update_vid_embedding, outputs=out).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template],
+            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
         )
 
         # origin_out = gr.Textbox(visible=False)
@@ -346,14 +351,14 @@ def create_vector_graph_block():
             outputs=[out],
         ).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template],
+            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
         )
 
         graph_loading_bt.click(import_graph_data, inputs=[out, input_schema], outputs=[out]).then(
             update_vid_embedding
         ).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template],
+            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
         )
 
         # TODO: we should store the examples after the user changed them.
@@ -367,6 +372,7 @@ def create_vector_graph_block():
                 input_text,
                 input_schema,
                 info_extract_template,
+                graph_split_type,
             ],  # TODO: Store the updated examples
         )
 

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -270,6 +270,12 @@ def create_vector_graph_block():
                     graph_data_btn0 = gr.Button("Clear Graph Data", size="sm")
 
             vector_import_bt = gr.Button("Import into Vector", variant="primary")
+            graph_split_type = gr.Dropdown(
+                choices=["document", "paragraph", "sentence"],
+                value="document",
+                label="Graph Extraction Split Type",
+                info=("document keeps the current behavior; paragraph/sentence split long docs before extraction."),
+            )
             graph_extract_bt = gr.Button("Extract Graph Data (1)", variant="primary")
             graph_loading_bt = gr.Button("Load into GraphDB (2)", interactive=True)
             graph_index_rebuild_bt = gr.Button("Update Vid Embedding")
@@ -330,7 +336,13 @@ def create_vector_graph_block():
         # origin_out = gr.Textbox(visible=False)
         graph_extract_bt.click(
             extract_graph,
-            inputs=[input_file, input_text, input_schema, info_extract_template],
+            inputs=[
+                input_file,
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+            ],
             outputs=[out],
         ).then(
             store_prompt,

--- a/hugegraph-llm/src/hugegraph_llm/flows/graph_extract.py
+++ b/hugegraph-llm/src/hugegraph_llm/flows/graph_extract.py
@@ -19,12 +19,12 @@ from pycgraph import GPipeline
 
 from hugegraph_llm.flows.common import BaseFlow
 from hugegraph_llm.nodes.document_node.chunk_split import ChunkSplitNode
+from hugegraph_llm.nodes.hugegraph_node.schema import SchemaNode
+from hugegraph_llm.nodes.llm_node.extract_info import ExtractNode
 from hugegraph_llm.operators.document_op.chunk_split import (
     SPLIT_TYPE_DOCUMENT,
     VALID_SPLIT_TYPES,
 )
-from hugegraph_llm.nodes.hugegraph_node.schema import SchemaNode
-from hugegraph_llm.nodes.llm_node.extract_info import ExtractNode
 from hugegraph_llm.state.ai_state import WkFlowInput, WkFlowState
 from hugegraph_llm.utils.log import log
 

--- a/hugegraph-llm/src/hugegraph_llm/flows/graph_extract.py
+++ b/hugegraph-llm/src/hugegraph_llm/flows/graph_extract.py
@@ -19,6 +19,10 @@ from pycgraph import GPipeline
 
 from hugegraph_llm.flows.common import BaseFlow
 from hugegraph_llm.nodes.document_node.chunk_split import ChunkSplitNode
+from hugegraph_llm.operators.document_op.chunk_split import (
+    SPLIT_TYPE_DOCUMENT,
+    VALID_SPLIT_TYPES,
+)
 from hugegraph_llm.nodes.hugegraph_node.schema import SchemaNode
 from hugegraph_llm.nodes.llm_node.extract_info import ExtractNode
 from hugegraph_llm.state.ai_state import WkFlowInput, WkFlowState
@@ -37,22 +41,43 @@ class GraphExtractFlow(BaseFlow):
         texts,
         example_prompt,
         extract_type,
+        split_type=SPLIT_TYPE_DOCUMENT,
         language="zh",
         **kwargs,
     ):
         # prepare input data
         prepared_input.texts = texts
         prepared_input.language = language
-        prepared_input.split_type = "document"
+        if split_type not in VALID_SPLIT_TYPES:
+            raise ValueError("split_type must be document, paragraph, or sentence")
+
+        prepared_input.split_type = split_type
         prepared_input.example_prompt = example_prompt
         prepared_input.schema = schema
         prepared_input.extract_type = extract_type
 
-    def build_flow(self, schema, texts, example_prompt, extract_type, language="zh", **kwargs):
+    def build_flow(
+        self,
+        schema,
+        texts,
+        example_prompt,
+        extract_type,
+        split_type=SPLIT_TYPE_DOCUMENT,
+        language="zh",
+        **kwargs,
+    ):
         pipeline = GPipeline()
         prepared_input = WkFlowInput()
         # prepare input data
-        self.prepare(prepared_input, schema, texts, example_prompt, extract_type, language)
+        self.prepare(
+            prepared_input,
+            schema,
+            texts,
+            example_prompt,
+            extract_type,
+            split_type,
+            language,
+        )
 
         pipeline.createGParam(prepared_input, "wkflow_input")
         pipeline.createGParam(WkFlowState(), "wkflow_state")
@@ -70,6 +95,8 @@ class GraphExtractFlow(BaseFlow):
         res = pipeline.getGParamWithNoEmpty("wkflow_state").to_json()
         vertices = res.get("vertices", [])
         edges = res.get("edges", [])
+        chunk_count = len(res.get("chunks", []))
+        log.info("Graph extraction chunk_count: %s", chunk_count)
         if not vertices and not edges:
             log.info("Please check the schema.(The schema may not match the Doc)")
             return json.dumps(

--- a/hugegraph-llm/src/hugegraph_llm/operators/document_op/chunk_split.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/document_op/chunk_split.py
@@ -16,6 +16,7 @@
 # under the License.
 
 
+import re
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -31,6 +32,11 @@ VALID_SPLIT_TYPES = (
     SPLIT_TYPE_PARAGRAPH,
     SPLIT_TYPE_SENTENCE,
 )
+
+
+def _split_sentence_boundaries(text: str) -> list[str]:
+    sentence_pattern = re.compile(r"[^.!?\u3002\uff01\uff1f\uff1b;]+[.!?\u3002\uff01\uff1f\uff1b;]*")
+    return [sentence.strip() for sentence in sentence_pattern.findall(text) if sentence.strip()]
 
 
 class ChunkSplit:
@@ -61,7 +67,7 @@ class ChunkSplit:
                 chunk_size=500, chunk_overlap=30, separators=self.separators
             ).split_text
         if split_type == SPLIT_TYPE_SENTENCE:
-            return RecursiveCharacterTextSplitter(chunk_size=50, chunk_overlap=0, separators=self.separators).split_text
+            return _split_sentence_boundaries
         raise ValueError("split_type must be document, paragraph, or sentence")
 
     def run(self, context: Optional[Dict[str, Any]]) -> Dict[str, Any]:

--- a/hugegraph-llm/src/hugegraph_llm/operators/document_op/chunk_split.py
+++ b/hugegraph-llm/src/hugegraph_llm/operators/document_op/chunk_split.py
@@ -26,6 +26,11 @@ LANGUAGE_EN = "en"
 SPLIT_TYPE_DOCUMENT = "document"
 SPLIT_TYPE_PARAGRAPH = "paragraph"
 SPLIT_TYPE_SENTENCE = "sentence"
+VALID_SPLIT_TYPES = (
+    SPLIT_TYPE_DOCUMENT,
+    SPLIT_TYPE_PARAGRAPH,
+    SPLIT_TYPE_SENTENCE,
+)
 
 
 class ChunkSplit:
@@ -57,7 +62,7 @@ class ChunkSplit:
             ).split_text
         if split_type == SPLIT_TYPE_SENTENCE:
             return RecursiveCharacterTextSplitter(chunk_size=50, chunk_overlap=0, separators=self.separators).split_text
-        raise ValueError("Type must be paragraph, sentence, html or markdown")
+        raise ValueError("split_type must be document, paragraph, or sentence")
 
     def run(self, context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         all_chunks = []

--- a/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
@@ -101,7 +101,7 @@ def extract_graph(
             texts,
             example_prompt,
             "property_graph",
-            split_type,
+            split_type=split_type,
         )
     except Exception as e:  # pylint: disable=broad-exception-caught
         log.error(e)

--- a/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
+++ b/hugegraph-llm/src/hugegraph_llm/utils/graph_index_utils.py
@@ -24,6 +24,10 @@ from pyhugegraph.client import PyHugeClient
 
 from hugegraph_llm.flows import FlowName
 from hugegraph_llm.flows.scheduler import SchedulerSingleton
+from hugegraph_llm.operators.document_op.chunk_split import (
+    SPLIT_TYPE_DOCUMENT,
+    VALID_SPLIT_TYPES,
+)
 
 from ..config import huge_settings
 from .hugegraph_utils import clean_hg_data
@@ -77,14 +81,28 @@ def clean_all_graph_data():
     gr.Info("Clear graph data successfully!")
 
 
-def extract_graph(input_file, input_text, schema, example_prompt) -> str:
+def extract_graph(
+    input_file,
+    input_text,
+    schema,
+    example_prompt,
+    split_type=SPLIT_TYPE_DOCUMENT,
+) -> str:
     texts = read_documents(input_file, input_text)
     scheduler = SchedulerSingleton.get_instance()
     if not schema:
         return "ERROR: please input with correct schema/format."
-
+    if split_type not in VALID_SPLIT_TYPES:
+        raise gr.Error("split_type must be document, paragraph, or sentence")
     try:
-        return scheduler.schedule_flow(FlowName.GRAPH_EXTRACT, schema, texts, example_prompt, "property_graph")
+        return scheduler.schedule_flow(
+            FlowName.GRAPH_EXTRACT,
+            schema,
+            texts,
+            example_prompt,
+            "property_graph",
+            split_type,
+        )
     except Exception as e:  # pylint: disable=broad-exception-caught
         log.error(e)
         raise gr.Error(str(e))

--- a/hugegraph-llm/src/tests/document/test_graph_extract_configurable_split.py
+++ b/hugegraph-llm/src/tests/document/test_graph_extract_configurable_split.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 
 import json
+from types import SimpleNamespace
 
 import gradio as gr
 import pytest
 
+from hugegraph_llm.config.models import base_prompt_config
+from hugegraph_llm.config.models.base_prompt_config import BasePromptConfig
 from hugegraph_llm.flows import FlowName
 from hugegraph_llm.flows.graph_extract import GraphExtractFlow
 from hugegraph_llm.operators.document_op.chunk_split import ChunkSplit
@@ -28,9 +31,11 @@ from hugegraph_llm.utils import graph_index_utils
 class DummyScheduler:
     def __init__(self):
         self.calls = []
+        self.kwargs = []
 
-    def schedule_flow(self, *args):
+    def schedule_flow(self, *args, **kwargs):
         self.calls.append(args)
+        self.kwargs.append(kwargs)
         return "scheduled"
 
 
@@ -162,9 +167,9 @@ def test_extract_graph_helper_forwards_selected_split_type(monkeypatch):
             ["graph extraction text"],
             "extract prompt",
             "property_graph",
-            "sentence",
         )
     ]
+    assert scheduler.kwargs == [{"split_type": "sentence"}]
 
 
 def test_extract_graph_helper_rejects_invalid_split_type(monkeypatch):
@@ -201,3 +206,33 @@ def test_graph_extract_post_deal_logs_chunk_count(monkeypatch):
 
     assert result_data["vertices"] == [{"id": "person:alice"}]
     assert any(message == "Graph extraction chunk_count: %s" and args == (2,) for message, args in log_calls)
+
+
+def test_sentence_split_returns_punctuation_delimited_sentences():
+    chunks = ChunkSplit(
+        "Alpha sentence one. Beta sentence two? Gamma sentence three!",
+        "sentence",
+        "en",
+    ).run(None)["chunks"]
+
+    assert chunks == [
+        "Alpha sentence one.",
+        "Beta sentence two?",
+        "Gamma sentence three!",
+    ]
+
+
+def test_prompt_config_round_trips_graph_extract_split_type(monkeypatch, tmp_path):
+    prompt_path = tmp_path / "config_prompt.yaml"
+    monkeypatch.setattr(base_prompt_config, "yaml_file_path", str(prompt_path))
+
+    config = BasePromptConfig()
+    config.llm_settings = SimpleNamespace(language="en")
+    config.graph_extract_split_type = "sentence"
+    config.save_to_yaml()
+
+    reloaded = BasePromptConfig()
+    reloaded.llm_settings = SimpleNamespace(language="en")
+    reloaded.ensure_yaml_file_exists()
+
+    assert reloaded.graph_extract_split_type == "sentence"

--- a/hugegraph-llm/src/tests/document/test_graph_extract_configurable_split.py
+++ b/hugegraph-llm/src/tests/document/test_graph_extract_configurable_split.py
@@ -49,6 +49,17 @@ class DummyPipeline:
         return DummyPipelineState()
 
 
+class CapturePipeline:
+    def __init__(self):
+        self.params = {}
+
+    def createGParam(self, value, name):
+        self.params[name] = value
+
+    def registerGElement(self, *args):
+        return None
+
+
 def test_graph_extract_prepare_preserves_default_document_split_type():
     prepared_input = WkFlowInput()
 
@@ -90,6 +101,25 @@ def test_graph_extract_prepare_rejects_invalid_split_type():
             "property_graph",
             "invalid",
         )
+
+
+def test_graph_extract_build_flow_passes_non_default_split_type_to_workflow_input(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "hugegraph_llm.flows.graph_extract.GPipeline",
+        CapturePipeline,
+    )
+
+    pipeline = GraphExtractFlow().build_flow(
+        "{}",
+        ["first paragraph\n\nsecond paragraph"],
+        "extract prompt",
+        "property_graph",
+        "paragraph",
+    )
+
+    assert pipeline.params["wkflow_input"].split_type == "paragraph"
 
 
 def test_chunk_split_non_default_types_produce_multiple_chunks():

--- a/hugegraph-llm/src/tests/document/test_graph_extract_configurable_split.py
+++ b/hugegraph-llm/src/tests/document/test_graph_extract_configurable_split.py
@@ -1,0 +1,173 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import gradio as gr
+import pytest
+
+from hugegraph_llm.flows import FlowName
+from hugegraph_llm.flows.graph_extract import GraphExtractFlow
+from hugegraph_llm.operators.document_op.chunk_split import ChunkSplit
+from hugegraph_llm.state.ai_state import WkFlowInput
+from hugegraph_llm.utils import graph_index_utils
+
+
+class DummyScheduler:
+    def __init__(self):
+        self.calls = []
+
+    def schedule_flow(self, *args):
+        self.calls.append(args)
+        return "scheduled"
+
+
+class DummyPipelineState:
+    def to_json(self):
+        return {
+            "chunks": ["chunk one", "chunk two"],
+            "vertices": [{"id": "person:alice"}],
+            "edges": [],
+        }
+
+
+class DummyPipeline:
+    def getGParamWithNoEmpty(self, name):
+        assert name == "wkflow_state"
+        return DummyPipelineState()
+
+
+def test_graph_extract_prepare_preserves_default_document_split_type():
+    prepared_input = WkFlowInput()
+
+    GraphExtractFlow().prepare(
+        prepared_input,
+        "{}",
+        ["first document"],
+        "extract prompt",
+        "property_graph",
+    )
+
+    assert prepared_input.split_type == "document"
+
+
+def test_graph_extract_prepare_accepts_non_default_split_type():
+    prepared_input = WkFlowInput()
+
+    GraphExtractFlow().prepare(
+        prepared_input,
+        "{}",
+        ["first paragraph\n\nsecond paragraph"],
+        "extract prompt",
+        "property_graph",
+        "paragraph",
+    )
+
+    assert prepared_input.split_type == "paragraph"
+
+
+def test_graph_extract_prepare_rejects_invalid_split_type():
+    prepared_input = WkFlowInput()
+
+    with pytest.raises(ValueError, match="split_type must be document"):
+        GraphExtractFlow().prepare(
+            prepared_input,
+            "{}",
+            ["first document"],
+            "extract prompt",
+            "property_graph",
+            "invalid",
+        )
+
+
+def test_chunk_split_non_default_types_produce_multiple_chunks():
+    paragraph_text = ("Alpha " * 120) + "\n\n" + ("Beta " * 120)
+    sentence_text = "Alpha sentence. Beta sentence. Gamma sentence. Delta sentence. Epsilon sentence. Zeta sentence."
+
+    paragraph_chunks = ChunkSplit(paragraph_text, "paragraph", "en").run(None)["chunks"]
+    sentence_chunks = ChunkSplit(sentence_text, "sentence", "en").run(None)["chunks"]
+
+    assert len(paragraph_chunks) > 1
+    assert len(sentence_chunks) > 1
+
+
+def test_extract_graph_helper_forwards_selected_split_type(monkeypatch):
+    scheduler = DummyScheduler()
+    monkeypatch.setattr(
+        graph_index_utils,
+        "read_documents",
+        lambda input_file, input_text: ["graph extraction text"],
+    )
+    monkeypatch.setattr(
+        graph_index_utils.SchedulerSingleton,
+        "get_instance",
+        lambda: scheduler,
+    )
+
+    result = graph_index_utils.extract_graph(
+        [],
+        "",
+        "{}",
+        "extract prompt",
+        "sentence",
+    )
+
+    assert result == "scheduled"
+    assert scheduler.calls == [
+        (
+            FlowName.GRAPH_EXTRACT,
+            "{}",
+            ["graph extraction text"],
+            "extract prompt",
+            "property_graph",
+            "sentence",
+        )
+    ]
+
+
+def test_extract_graph_helper_rejects_invalid_split_type(monkeypatch):
+    monkeypatch.setattr(
+        graph_index_utils,
+        "read_documents",
+        lambda input_file, input_text: ["graph extraction text"],
+    )
+    monkeypatch.setattr(
+        graph_index_utils.SchedulerSingleton,
+        "get_instance",
+        lambda: DummyScheduler(),
+    )
+
+    with pytest.raises(gr.Error, match="split_type must be document"):
+        graph_index_utils.extract_graph(
+            [],
+            "",
+            "{}",
+            "extract prompt",
+            "invalid",
+        )
+
+
+def test_graph_extract_post_deal_logs_chunk_count(monkeypatch):
+    log_calls = []
+    monkeypatch.setattr(
+        "hugegraph_llm.flows.graph_extract.log.info",
+        lambda message, *args: log_calls.append((message, args)),
+    )
+
+    result = GraphExtractFlow().post_deal(DummyPipeline())
+    result_data = json.loads(result)
+
+    assert result_data["vertices"] == [{"id": "person:alice"}]
+    assert any(message == "Graph extraction chunk_count: %s" and args == (2,) for message, args in log_calls)


### PR DESCRIPTION
## Purpose

Closes #343.

This PR makes the graph extraction split type configurable instead of always forcing `document`.

## Design

The graph extraction flow now accepts an optional `split_type` argument and keeps `document` as the default to preserve the existing behavior.

## Split modes

This PR keeps `document` as the default graph extraction split mode to preserve the existing behavior.

Supported graph extraction split modes:

* `document`: keeps each uploaded or raw document as one chunk.
* `paragraph`: uses the existing paragraph chunking strategy with `chunk_size=500`, `chunk_overlap=30`, and language-aware separators.
* `sentence`: uses punctuation-based sentence-boundary splitting for `.`, `?`, `!`, `。`, `？`, `！`, `；`, and `;`.

The selected split mode is passed from the demo UI to `extract_graph()`, then forwarded to `SchedulerSingleton.schedule_flow(..., split_type=split_type)`, and finally used by `GraphExtractFlow.prepare()` / `build_flow()`.

The selected split mode is also persisted through the prompt config and restored into the demo dropdown after reload.

Invalid split types fail early with a clear error message listing the supported values.

The existing `vertices` / `edges` JSON contract used by “Load into GraphDB” is preserved. `chunk_count` is logged for debugging instead of being added to the returned JSON.

For PDF compatibility, this PR treats extracted PDF text the same as other text input and includes representative PDF-like extracted text coverage in tests.

## Changes

* Added configurable graph extraction split type support.
* Added `document`, `paragraph`, and `sentence` split mode options in the demo UI.
* Forwarded the selected split mode through `extract_graph()` and the graph extraction flow.
* Persisted the selected split mode through the prompt config path.
* Added punctuation-based sentence-boundary splitting for `sentence` mode.
* Added tests for default behavior, non-default split modes, invalid split type handling, helper forwarding, prompt config persistence, sentence splitting, long document splitting, and representative PDF-like extracted text.

## Tests

* `uv run ruff format --check .`
* `uv run pytest src/tests/document/test_graph_extract_configurable_split.py`
* `uv run pytest src/tests/document`

