### PR TITLE
feat: persist schema generator examples

### DIFF
--- a/hugegraph-llm/src/hugegraph_llm/config/models/base_prompt_config.py
+++ b/hugegraph-llm/src/hugegraph_llm/config/models/base_prompt_config.py
@@ -79,6 +79,8 @@ class BasePromptConfig:
     gremlin_generate_prompt: str = ""
     doc_input_text: str = ""
     graph_extract_split_type: str = "document"
+    schema_generator_query_examples: str = ""
+    schema_generator_few_shot_examples: str = ""
     _language_generated: str = ""
     generate_extract_prompt_template: str = ""
 
@@ -138,6 +140,8 @@ class BasePromptConfig:
             "gremlin_generate_prompt": to_literal(self.gremlin_generate_prompt),
             "doc_input_text": to_literal(self.doc_input_text),
             "graph_extract_split_type": to_literal(self.graph_extract_split_type),
+            "schema_generator_query_examples": to_literal(self.schema_generator_query_examples),
+            "schema_generator_few_shot_examples": to_literal(self.schema_generator_few_shot_examples),
             "_language_generated": str(self.llm_settings.language).lower().strip(),
             "generate_extract_prompt_template": to_literal(self.generate_extract_prompt_template),
         }

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -45,8 +45,9 @@ from hugegraph_llm.utils.vector_index_utils import (
 
 
 def _validate_schema_generator_examples(examples, label):
-    if examples is None:
-        return None
+    examples = (examples or "").strip()
+    if not examples:
+        return ""
     try:
         json.loads(examples)
     except json.JSONDecodeError as exc:
@@ -66,37 +67,39 @@ def _load_persisted_json_examples(examples, label):
     return examples
 
 
+def _persist_schema_generator_examples(query_examples, few_shot_examples):
+    validated_query_examples = _validate_schema_generator_examples(query_examples, "Query examples")
+    validated_few_shot_examples = _validate_schema_generator_examples(few_shot_examples, "Few-shot schema examples")
+
+    changed = False
+    if getattr(prompt, "schema_generator_query_examples", "") != validated_query_examples:
+        prompt.schema_generator_query_examples = validated_query_examples
+        changed = True
+
+    if getattr(prompt, "schema_generator_few_shot_examples", "") != validated_few_shot_examples:
+        prompt.schema_generator_few_shot_examples = validated_few_shot_examples
+        changed = True
+
+    if changed:
+        prompt.update_yaml_file()
+
+    effective_query_examples = validated_query_examples or load_query_examples()
+    effective_few_shot_examples = validated_few_shot_examples or load_schema_fewshot_examples()
+    return effective_query_examples, effective_few_shot_examples
+
+
 def store_prompt(
     doc,
     schema,
     example_prompt,
     graph_extract_split_type="document",
-    query_examples=None,
-    few_shot_examples=None,
 ):
-    validated_query_examples = _validate_schema_generator_examples(query_examples, "Query examples")
-    validated_few_shot_examples = _validate_schema_generator_examples(few_shot_examples, "Few-shot schema examples")
-
-    changed = (
+    if (
         prompt.doc_input_text != doc
         or prompt.graph_schema != schema
         or prompt.extract_graph_prompt != example_prompt
         or prompt.graph_extract_split_type != graph_extract_split_type
-    )
-
-    if validated_query_examples is not None and (
-        getattr(prompt, "schema_generator_query_examples", "") != validated_query_examples
     ):
-        prompt.schema_generator_query_examples = validated_query_examples
-        changed = True
-
-    if validated_few_shot_examples is not None and (
-        getattr(prompt, "schema_generator_few_shot_examples", "") != validated_few_shot_examples
-    ):
-        prompt.schema_generator_few_shot_examples = validated_few_shot_examples
-        changed = True
-
-    if changed:
         prompt.doc_input_text = doc
         prompt.graph_schema = schema
         prompt.extract_graph_prompt = example_prompt
@@ -265,8 +268,7 @@ def _create_prompt_helper_block(demo, input_text, info_extract_template):
 
 
 def _build_schema_and_provide_feedback(input_text, query_example, few_shot):
-    _validate_schema_generator_examples(query_example, "Query examples")
-    _validate_schema_generator_examples(few_shot, "Few-shot schema examples")
+    query_example, few_shot = _persist_schema_generator_examples(query_example, few_shot)
     gr.Info("Generating schema, please wait...")
     # Call the original build_schema function
     generated_schema = build_schema(input_text, query_example, few_shot)
@@ -378,8 +380,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],
         )
         vector_index_btn1.click(clean_vector_index).then(
@@ -389,8 +389,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],
         )
         vector_import_bt.click(build_vector_index, inputs=[input_file, input_text], outputs=out).then(
@@ -400,8 +398,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],
         )
         graph_index_btn0.click(get_graph_index_info, outputs=out).then(
@@ -411,8 +407,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],
         )
         graph_index_btn1.click(clean_all_graph_index).then(
@@ -422,8 +416,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],
         )
         graph_data_btn0.click(clean_all_graph_data).then(
@@ -433,8 +425,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],
         )
         graph_index_rebuild_bt.click(update_vid_embedding, outputs=out).then(
@@ -444,8 +434,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],
         )
 
@@ -467,8 +455,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],
         )
 
@@ -481,8 +467,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],
         )
 
@@ -498,8 +482,6 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-                query_example,
-                few_shot,
             ],  # Persist the updated schema-generator examples
         )
 

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -44,15 +44,75 @@ from hugegraph_llm.utils.vector_index_utils import (
 )
 
 
-def _validate_schema_generator_examples(examples, label):
+def _dump_json_examples(value):
+    return json.dumps(value, indent=2, ensure_ascii=False)
+
+
+def _normalize_schema_generator_query_examples(examples):
     examples = (examples or "").strip()
     if not examples:
         return ""
+
     try:
-        json.loads(examples)
+        parsed_examples = json.loads(examples)
     except json.JSONDecodeError as exc:
-        raise gr.Error(f"{label} must be valid JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}") from exc
-    return examples
+        raise gr.Error(
+            f"Query examples must be valid JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}"
+        ) from exc
+
+    if not isinstance(parsed_examples, list):
+        raise gr.Error("Query examples must be a JSON list.")
+
+    normalized_examples = []
+    for index, item in enumerate(parsed_examples):
+        if isinstance(item, str):
+            description = item.strip()
+            if not description:
+                raise gr.Error(f"Query examples[{index}] must be a non-empty string.")
+            normalized_examples.append(
+                {
+                    "description": description,
+                    "gremlin": "",
+                }
+            )
+            continue
+
+        if isinstance(item, dict):
+            description = item.get("description")
+            gremlin = item.get("gremlin")
+            if not isinstance(description, str) or not description.strip():
+                raise gr.Error("Each query example object must contain a non-empty `description` string.")
+            if not isinstance(gremlin, str):
+                raise gr.Error("Each query example object must contain a `gremlin` string.")
+            normalized_examples.append(
+                {
+                    "description": description.strip(),
+                    "gremlin": gremlin.strip(),
+                }
+            )
+            continue
+
+        raise gr.Error("Query examples must contain strings or objects with `description` and `gremlin` fields.")
+
+    return _dump_json_examples(normalized_examples)
+
+
+def _validate_schema_generator_few_shot_examples(examples):
+    examples = (examples or "").strip()
+    if not examples:
+        return ""
+
+    try:
+        parsed_examples = json.loads(examples)
+    except json.JSONDecodeError as exc:
+        raise gr.Error(
+            f"Few-shot schema examples must be valid JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}"
+        ) from exc
+
+    if not isinstance(parsed_examples, dict):
+        raise gr.Error("Few-shot schema examples must be a JSON object.")
+
+    return _dump_json_examples(parsed_examples)
 
 
 def _load_persisted_json_examples(examples, label):
@@ -68,8 +128,8 @@ def _load_persisted_json_examples(examples, label):
 
 
 def _persist_schema_generator_examples(query_examples, few_shot_examples):
-    validated_query_examples = _validate_schema_generator_examples(query_examples, "Query examples")
-    validated_few_shot_examples = _validate_schema_generator_examples(few_shot_examples, "Few-shot schema examples")
+    validated_query_examples = _normalize_schema_generator_query_examples(query_examples)
+    validated_few_shot_examples = _validate_schema_generator_few_shot_examples(few_shot_examples)
 
     changed = False
     if getattr(prompt, "schema_generator_query_examples", "") != validated_query_examples:
@@ -143,7 +203,7 @@ def load_query_examples():
         "schema generator query examples",
     )
     if persisted_examples:
-        return persisted_examples
+        return _normalize_schema_generator_query_examples(persisted_examples)
 
     try:
         language = getattr(
@@ -158,13 +218,13 @@ def load_query_examples():
 
         with open(examples_path, "r", encoding="utf-8") as f:
             examples = json.load(f)
-        return json.dumps(examples, indent=2, ensure_ascii=False)
+        return _normalize_schema_generator_query_examples(json.dumps(examples, ensure_ascii=False))
     except (FileNotFoundError, json.JSONDecodeError):
         try:
             examples_path = os.path.join(resource_path, "prompt_examples", "query_examples.json")
             with open(examples_path, "r", encoding="utf-8") as f:
                 examples = json.load(f)
-            return json.dumps(examples, indent=2, ensure_ascii=False)
+            return _normalize_schema_generator_query_examples(json.dumps(examples, ensure_ascii=False))
         except (FileNotFoundError, json.JSONDecodeError):
             return "[]"
 
@@ -176,13 +236,13 @@ def load_schema_fewshot_examples():
         "schema generator few-shot examples",
     )
     if persisted_examples:
-        return persisted_examples
+        return _validate_schema_generator_few_shot_examples(persisted_examples)
 
     try:
         examples_path = os.path.join(resource_path, "prompt_examples", "schema_examples.json")
         with open(examples_path, "r", encoding="utf-8") as f:
             examples = json.load(f)
-        return json.dumps(examples, indent=2, ensure_ascii=False)
+        return _validate_schema_generator_few_shot_examples(json.dumps(examples, ensure_ascii=False))
     except (FileNotFoundError, json.JSONDecodeError):
         return "[]"
 

--- a/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
+++ b/hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py
@@ -44,13 +44,59 @@ from hugegraph_llm.utils.vector_index_utils import (
 )
 
 
-def store_prompt(doc, schema, example_prompt, graph_extract_split_type="document"):
-    if (
+def _validate_schema_generator_examples(examples, label):
+    if examples is None:
+        return None
+    try:
+        json.loads(examples)
+    except json.JSONDecodeError as exc:
+        raise gr.Error(f"{label} must be valid JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}") from exc
+    return examples
+
+
+def _load_persisted_json_examples(examples, label):
+    examples = (examples or "").strip()
+    if not examples:
+        return ""
+    try:
+        json.loads(examples)
+    except json.JSONDecodeError as exc:
+        log.warning("Ignoring invalid persisted %s: %s", label, exc)
+        return ""
+    return examples
+
+
+def store_prompt(
+    doc,
+    schema,
+    example_prompt,
+    graph_extract_split_type="document",
+    query_examples=None,
+    few_shot_examples=None,
+):
+    validated_query_examples = _validate_schema_generator_examples(query_examples, "Query examples")
+    validated_few_shot_examples = _validate_schema_generator_examples(few_shot_examples, "Few-shot schema examples")
+
+    changed = (
         prompt.doc_input_text != doc
         or prompt.graph_schema != schema
         or prompt.extract_graph_prompt != example_prompt
         or prompt.graph_extract_split_type != graph_extract_split_type
+    )
+
+    if validated_query_examples is not None and (
+        getattr(prompt, "schema_generator_query_examples", "") != validated_query_examples
     ):
+        prompt.schema_generator_query_examples = validated_query_examples
+        changed = True
+
+    if validated_few_shot_examples is not None and (
+        getattr(prompt, "schema_generator_few_shot_examples", "") != validated_few_shot_examples
+    ):
+        prompt.schema_generator_few_shot_examples = validated_few_shot_examples
+        changed = True
+
+    if changed:
         prompt.doc_input_text = doc
         prompt.graph_schema = schema
         prompt.extract_graph_prompt = example_prompt
@@ -89,6 +135,13 @@ def load_example_names():
 
 def load_query_examples():
     """Load query examples from JSON file based on the prompt language setting"""
+    persisted_examples = _load_persisted_json_examples(
+        getattr(prompt, "schema_generator_query_examples", ""),
+        "schema generator query examples",
+    )
+    if persisted_examples:
+        return persisted_examples
+
     try:
         language = getattr(
             prompt,
@@ -115,6 +168,13 @@ def load_query_examples():
 
 def load_schema_fewshot_examples():
     """Load few-shot examples from a JSON file"""
+    persisted_examples = _load_persisted_json_examples(
+        getattr(prompt, "schema_generator_few_shot_examples", ""),
+        "schema generator few-shot examples",
+    )
+    if persisted_examples:
+        return persisted_examples
+
     try:
         examples_path = os.path.join(resource_path, "prompt_examples", "schema_examples.json")
         with open(examples_path, "r", encoding="utf-8") as f:
@@ -205,6 +265,8 @@ def _create_prompt_helper_block(demo, input_text, info_extract_template):
 
 
 def _build_schema_and_provide_feedback(input_text, query_example, few_shot):
+    _validate_schema_generator_examples(query_example, "Query examples")
+    _validate_schema_generator_examples(few_shot, "Few-shot schema examples")
     gr.Info("Generating schema, please wait...")
     # Call the original build_schema function
     generated_schema = build_schema(input_text, query_example, few_shot)
@@ -311,31 +373,80 @@ def create_vector_graph_block():
 
         vector_index_btn0.click(get_vector_index_info, outputs=out).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
+            inputs=[
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+                query_example,
+                few_shot,
+            ],
         )
         vector_index_btn1.click(clean_vector_index).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
+            inputs=[
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+                query_example,
+                few_shot,
+            ],
         )
         vector_import_bt.click(build_vector_index, inputs=[input_file, input_text], outputs=out).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
+            inputs=[
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+                query_example,
+                few_shot,
+            ],
         )
         graph_index_btn0.click(get_graph_index_info, outputs=out).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
+            inputs=[
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+                query_example,
+                few_shot,
+            ],
         )
         graph_index_btn1.click(clean_all_graph_index).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
+            inputs=[
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+                query_example,
+                few_shot,
+            ],
         )
         graph_data_btn0.click(clean_all_graph_data).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
+            inputs=[
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+                query_example,
+                few_shot,
+            ],
         )
         graph_index_rebuild_bt.click(update_vid_embedding, outputs=out).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
+            inputs=[
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+                query_example,
+                few_shot,
+            ],
         )
 
         # origin_out = gr.Textbox(visible=False)
@@ -351,14 +462,28 @@ def create_vector_graph_block():
             outputs=[out],
         ).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
+            inputs=[
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+                query_example,
+                few_shot,
+            ],
         )
 
         graph_loading_bt.click(import_graph_data, inputs=[out, input_schema], outputs=[out]).then(
             update_vid_embedding
         ).then(
             store_prompt,
-            inputs=[input_text, input_schema, info_extract_template, graph_split_type],
+            inputs=[
+                input_text,
+                input_schema,
+                info_extract_template,
+                graph_split_type,
+                query_example,
+                few_shot,
+            ],
         )
 
         # TODO: we should store the examples after the user changed them.
@@ -373,7 +498,9 @@ def create_vector_graph_block():
                 input_schema,
                 info_extract_template,
                 graph_split_type,
-            ],  # TODO: Store the updated examples
+                query_example,
+                few_shot,
+            ],  # Persist the updated schema-generator examples
         )
 
         def on_tab_select(input_f, input_t, evt: gr.SelectData):

--- a/hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py
+++ b/hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py
@@ -1,0 +1,184 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from types import SimpleNamespace
+
+import gradio as gr
+import pytest
+
+from hugegraph_llm.config.models import base_prompt_config
+from hugegraph_llm.config.models.base_prompt_config import BasePromptConfig
+from hugegraph_llm.demo.rag_demo import vector_graph_block
+
+
+class DummyPrompt:
+    def __init__(self):
+        self.doc_input_text = ""
+        self.graph_schema = ""
+        self.extract_graph_prompt = ""
+        self.graph_extract_split_type = "document"
+        self.schema_generator_query_examples = ""
+        self.schema_generator_few_shot_examples = ""
+        self.llm_settings = SimpleNamespace(language="EN")
+        self.update_count = 0
+
+    def update_yaml_file(self):
+        self.update_count += 1
+
+
+def test_store_prompt_persists_schema_generator_examples(monkeypatch):
+    dummy_prompt = DummyPrompt()
+    monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+    query_examples = '[{"query": "who knows marko?"}]'
+    few_shot_examples = '[{"schema": {"vertices": []}}]'
+
+    vector_graph_block.store_prompt(
+        "doc",
+        "{}",
+        "extract prompt",
+        "document",
+        query_examples,
+        few_shot_examples,
+    )
+
+    assert dummy_prompt.doc_input_text == "doc"
+    assert dummy_prompt.graph_schema == "{}"
+    assert dummy_prompt.extract_graph_prompt == "extract prompt"
+    assert dummy_prompt.schema_generator_query_examples == query_examples
+    assert dummy_prompt.schema_generator_few_shot_examples == few_shot_examples
+    assert dummy_prompt.update_count == 1
+
+
+def test_store_prompt_rejects_invalid_query_examples(monkeypatch):
+    dummy_prompt = DummyPrompt()
+    monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+
+    with pytest.raises(gr.Error, match="Query examples must be valid JSON"):
+        vector_graph_block.store_prompt(
+            "doc",
+            "{}",
+            "extract prompt",
+            "document",
+            "{invalid json",
+            "[]",
+        )
+
+    assert dummy_prompt.schema_generator_query_examples == ""
+    assert dummy_prompt.schema_generator_few_shot_examples == ""
+    assert dummy_prompt.update_count == 0
+
+
+def test_build_schema_feedback_rejects_invalid_few_shot_before_flow(monkeypatch):
+    called = False
+
+    def fake_build_schema(*args):
+        nonlocal called
+        called = True
+        return "{}"
+
+    monkeypatch.setattr(vector_graph_block, "build_schema", fake_build_schema)
+
+    with pytest.raises(gr.Error, match="Few-shot schema examples must be valid JSON"):
+        vector_graph_block._build_schema_and_provide_feedback(
+            "source text",
+            "[]",
+            "{invalid json",
+        )
+
+    assert called is False
+
+
+def test_load_examples_prefers_persisted_prompt_values(monkeypatch):
+    dummy_prompt = DummyPrompt()
+    dummy_prompt.schema_generator_query_examples = '[{"saved_query": true}]'
+    dummy_prompt.schema_generator_few_shot_examples = '[{"saved_schema": true}]'
+    monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+
+    query_examples = json.loads(vector_graph_block.load_query_examples())
+    few_shot_examples = json.loads(vector_graph_block.load_schema_fewshot_examples())
+
+    assert query_examples == [{"saved_query": True}]
+    assert few_shot_examples == [{"saved_schema": True}]
+
+
+def test_load_examples_falls_back_to_bundled_resources(monkeypatch, tmp_path):
+    prompt_examples_dir = tmp_path / "prompt_examples"
+    prompt_examples_dir.mkdir()
+    (prompt_examples_dir / "query_examples.json").write_text(
+        '[{"bundled_query": true}]',
+        encoding="utf-8",
+    )
+    (prompt_examples_dir / "schema_examples.json").write_text(
+        '[{"bundled_schema": true}]',
+        encoding="utf-8",
+    )
+
+    dummy_prompt = DummyPrompt()
+    monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+    monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
+
+    query_examples = json.loads(vector_graph_block.load_query_examples())
+    few_shot_examples = json.loads(vector_graph_block.load_schema_fewshot_examples())
+
+    assert query_examples == [{"bundled_query": True}]
+    assert few_shot_examples == [{"bundled_schema": True}]
+
+
+def test_invalid_persisted_examples_fall_back_to_bundled_resources(
+    monkeypatch,
+    tmp_path,
+):
+    prompt_examples_dir = tmp_path / "prompt_examples"
+    prompt_examples_dir.mkdir()
+    (prompt_examples_dir / "query_examples.json").write_text(
+        '[{"bundled_query": true}]',
+        encoding="utf-8",
+    )
+    (prompt_examples_dir / "schema_examples.json").write_text(
+        '[{"bundled_schema": true}]',
+        encoding="utf-8",
+    )
+
+    dummy_prompt = DummyPrompt()
+    dummy_prompt.schema_generator_query_examples = "{invalid json"
+    dummy_prompt.schema_generator_few_shot_examples = "{invalid json"
+    monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+    monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
+
+    query_examples = json.loads(vector_graph_block.load_query_examples())
+    few_shot_examples = json.loads(vector_graph_block.load_schema_fewshot_examples())
+
+    assert query_examples == [{"bundled_query": True}]
+    assert few_shot_examples == [{"bundled_schema": True}]
+
+
+def test_old_prompt_config_without_schema_generator_examples_still_loads(
+    monkeypatch,
+    tmp_path,
+):
+    prompt_path = tmp_path / "config_prompt.yaml"
+    prompt_path.write_text(
+        "doc_input_text: old doc\ngraph_schema: '{}'\nextract_graph_prompt: old prompt\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(base_prompt_config, "yaml_file_path", str(prompt_path))
+
+    config = BasePromptConfig()
+    config.llm_settings = SimpleNamespace(language="EN")
+    config.ensure_yaml_file_exists()
+
+    assert config.schema_generator_query_examples == ""
+    assert config.schema_generator_few_shot_examples == ""

--- a/hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py
+++ b/hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py
@@ -40,39 +40,51 @@ class DummyPrompt:
         self.update_count += 1
 
 
-def test_store_prompt_persists_schema_generator_examples(monkeypatch):
+def _write_bundled_examples(tmp_path):
+    prompt_examples_dir = tmp_path / "prompt_examples"
+    prompt_examples_dir.mkdir()
+    (prompt_examples_dir / "query_examples.json").write_text(
+        '[{"bundled_query": true}]',
+        encoding="utf-8",
+    )
+    (prompt_examples_dir / "schema_examples.json").write_text(
+        '[{"bundled_schema": true}]',
+        encoding="utf-8",
+    )
+
+
+def test_schema_generator_persist_helper_saves_valid_examples(monkeypatch, tmp_path):
+    _write_bundled_examples(tmp_path)
     dummy_prompt = DummyPrompt()
     monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+    monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
+
     query_examples = '[{"query": "who knows marko?"}]'
     few_shot_examples = '[{"schema": {"vertices": []}}]'
 
-    vector_graph_block.store_prompt(
-        "doc",
-        "{}",
-        "extract prompt",
-        "document",
+    effective_query, effective_few_shot = vector_graph_block._persist_schema_generator_examples(
         query_examples,
         few_shot_examples,
     )
 
-    assert dummy_prompt.doc_input_text == "doc"
-    assert dummy_prompt.graph_schema == "{}"
-    assert dummy_prompt.extract_graph_prompt == "extract prompt"
+    assert effective_query == query_examples
+    assert effective_few_shot == few_shot_examples
     assert dummy_prompt.schema_generator_query_examples == query_examples
     assert dummy_prompt.schema_generator_few_shot_examples == few_shot_examples
     assert dummy_prompt.update_count == 1
 
 
-def test_store_prompt_rejects_invalid_query_examples(monkeypatch):
+def test_schema_generator_persist_helper_rejects_invalid_query_examples(
+    monkeypatch,
+    tmp_path,
+):
+    _write_bundled_examples(tmp_path)
     dummy_prompt = DummyPrompt()
     monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+    monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
 
     with pytest.raises(gr.Error, match="Query examples must be valid JSON"):
-        vector_graph_block.store_prompt(
-            "doc",
-            "{}",
-            "extract prompt",
-            "document",
+        vector_graph_block._persist_schema_generator_examples(
             "{invalid json",
             "[]",
         )
@@ -82,7 +94,70 @@ def test_store_prompt_rejects_invalid_query_examples(monkeypatch):
     assert dummy_prompt.update_count == 0
 
 
-def test_build_schema_feedback_rejects_invalid_few_shot_before_flow(monkeypatch):
+def test_blank_schema_generator_examples_clear_persisted_overrides_to_bundled(
+    monkeypatch,
+    tmp_path,
+):
+    _write_bundled_examples(tmp_path)
+    dummy_prompt = DummyPrompt()
+    dummy_prompt.schema_generator_query_examples = '[{"saved_query": true}]'
+    dummy_prompt.schema_generator_few_shot_examples = '[{"saved_schema": true}]'
+    monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+    monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
+
+    effective_query, effective_few_shot = vector_graph_block._persist_schema_generator_examples(
+        "   ",
+        "",
+    )
+
+    assert dummy_prompt.schema_generator_query_examples == ""
+    assert dummy_prompt.schema_generator_few_shot_examples == ""
+    assert json.loads(effective_query) == [{"bundled_query": True}]
+    assert json.loads(effective_few_shot) == [{"bundled_schema": True}]
+    assert dummy_prompt.update_count == 1
+
+
+def test_build_schema_feedback_persists_examples_before_running_flow(
+    monkeypatch,
+    tmp_path,
+):
+    _write_bundled_examples(tmp_path)
+    dummy_prompt = DummyPrompt()
+    monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+    monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
+
+    calls = []
+
+    def fake_build_schema(input_text, query_examples, few_shot_schema):
+        calls.append((input_text, query_examples, few_shot_schema))
+        return "{}"
+
+    monkeypatch.setattr(vector_graph_block, "build_schema", fake_build_schema)
+
+    query_examples = '[{"query": "who knows lop?"}]'
+    few_shot_examples = '[{"schema": {"edges": []}}]'
+
+    result = vector_graph_block._build_schema_and_provide_feedback(
+        "source text",
+        query_examples,
+        few_shot_examples,
+    )
+
+    assert result == "{}"
+    assert dummy_prompt.schema_generator_query_examples == query_examples
+    assert dummy_prompt.schema_generator_few_shot_examples == few_shot_examples
+    assert calls == [("source text", query_examples, few_shot_examples)]
+
+
+def test_build_schema_feedback_rejects_invalid_few_shot_before_flow(
+    monkeypatch,
+    tmp_path,
+):
+    _write_bundled_examples(tmp_path)
+    dummy_prompt = DummyPrompt()
+    monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
+    monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
+
     called = False
 
     def fake_build_schema(*args):
@@ -100,6 +175,7 @@ def test_build_schema_feedback_rejects_invalid_few_shot_before_flow(monkeypatch)
         )
 
     assert called is False
+    assert dummy_prompt.update_count == 0
 
 
 def test_load_examples_prefers_persisted_prompt_values(monkeypatch):
@@ -116,17 +192,7 @@ def test_load_examples_prefers_persisted_prompt_values(monkeypatch):
 
 
 def test_load_examples_falls_back_to_bundled_resources(monkeypatch, tmp_path):
-    prompt_examples_dir = tmp_path / "prompt_examples"
-    prompt_examples_dir.mkdir()
-    (prompt_examples_dir / "query_examples.json").write_text(
-        '[{"bundled_query": true}]',
-        encoding="utf-8",
-    )
-    (prompt_examples_dir / "schema_examples.json").write_text(
-        '[{"bundled_schema": true}]',
-        encoding="utf-8",
-    )
-
+    _write_bundled_examples(tmp_path)
     dummy_prompt = DummyPrompt()
     monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
     monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
@@ -142,17 +208,7 @@ def test_invalid_persisted_examples_fall_back_to_bundled_resources(
     monkeypatch,
     tmp_path,
 ):
-    prompt_examples_dir = tmp_path / "prompt_examples"
-    prompt_examples_dir.mkdir()
-    (prompt_examples_dir / "query_examples.json").write_text(
-        '[{"bundled_query": true}]',
-        encoding="utf-8",
-    )
-    (prompt_examples_dir / "schema_examples.json").write_text(
-        '[{"bundled_schema": true}]',
-        encoding="utf-8",
-    )
-
+    _write_bundled_examples(tmp_path)
     dummy_prompt = DummyPrompt()
     dummy_prompt.schema_generator_query_examples = "{invalid json"
     dummy_prompt.schema_generator_few_shot_examples = "{invalid json"
@@ -164,6 +220,13 @@ def test_invalid_persisted_examples_fall_back_to_bundled_resources(
 
     assert query_examples == [{"bundled_query": True}]
     assert few_shot_examples == [{"bundled_schema": True}]
+
+
+def test_generic_store_prompt_does_not_handle_schema_generator_examples():
+    parameters = inspect.signature(vector_graph_block.store_prompt).parameters
+
+    assert "query_examples" not in parameters
+    assert "few_shot_examples" not in parameters
 
 
 def test_old_prompt_config_without_schema_generator_examples_still_loads(
@@ -183,13 +246,3 @@ def test_old_prompt_config_without_schema_generator_examples_still_loads(
 
     assert config.schema_generator_query_examples == ""
     assert config.schema_generator_few_shot_examples == ""
-
-
-def test_demo_save_chains_pass_schema_generator_examples_to_store_prompt():
-    source = inspect.getsource(vector_graph_block)
-
-    assert "store_prompt" in source
-    assert "query_example" in source
-    assert "few_shot" in source
-    assert "schema_generator_query_examples" in source
-    assert "schema_generator_few_shot_examples" in source

--- a/hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py
+++ b/hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import json
 from types import SimpleNamespace
 
@@ -182,3 +183,13 @@ def test_old_prompt_config_without_schema_generator_examples_still_loads(
 
     assert config.schema_generator_query_examples == ""
     assert config.schema_generator_few_shot_examples == ""
+
+
+def test_demo_save_chains_pass_schema_generator_examples_to_store_prompt():
+    source = inspect.getsource(vector_graph_block)
+
+    assert "store_prompt" in source
+    assert "query_example" in source
+    assert "few_shot" in source
+    assert "schema_generator_query_examples" in source
+    assert "schema_generator_few_shot_examples" in source

--- a/hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py
+++ b/hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py
@@ -44,13 +44,54 @@ def _write_bundled_examples(tmp_path):
     prompt_examples_dir = tmp_path / "prompt_examples"
     prompt_examples_dir.mkdir()
     (prompt_examples_dir / "query_examples.json").write_text(
-        '[{"bundled_query": true}]',
+        '["Find all persons", "Find all webpages"]',
         encoding="utf-8",
     )
     (prompt_examples_dir / "schema_examples.json").write_text(
-        '[{"bundled_schema": true}]',
+        '{"vertexlabels": [], "edgelabels": []}',
         encoding="utf-8",
     )
+
+
+def test_query_examples_normalize_bundled_string_list_to_downstream_shape():
+    normalized = vector_graph_block._normalize_schema_generator_query_examples('["Find all persons"]')
+
+    assert json.loads(normalized) == [
+        {
+            "description": "Find all persons",
+            "gremlin": "",
+        }
+    ]
+
+
+def test_query_examples_accept_description_gremlin_object_shape():
+    normalized = vector_graph_block._normalize_schema_generator_query_examples(
+        json.dumps(
+            [
+                {
+                    "description": "Find persons",
+                    "gremlin": 'g.V().hasLabel("person")',
+                }
+            ]
+        )
+    )
+
+    assert json.loads(normalized) == [
+        {
+            "description": "Find persons",
+            "gremlin": 'g.V().hasLabel("person")',
+        }
+    ]
+
+
+def test_query_examples_reject_invalid_shape():
+    with pytest.raises(gr.Error, match="description"):
+        vector_graph_block._normalize_schema_generator_query_examples('[{"query": "Find persons"}]')
+
+
+def test_few_shot_examples_must_be_json_object():
+    with pytest.raises(gr.Error, match="JSON object"):
+        vector_graph_block._validate_schema_generator_few_shot_examples('[{"schema": {"vertices": []}}]')
 
 
 def test_schema_generator_persist_helper_saves_valid_examples(monkeypatch, tmp_path):
@@ -59,18 +100,26 @@ def test_schema_generator_persist_helper_saves_valid_examples(monkeypatch, tmp_p
     monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
     monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
 
-    query_examples = '[{"query": "who knows marko?"}]'
-    few_shot_examples = '[{"schema": {"vertices": []}}]'
+    query_examples = '["who knows marko?"]'
+    few_shot_examples = '{"vertexlabels": [], "edgelabels": []}'
 
     effective_query, effective_few_shot = vector_graph_block._persist_schema_generator_examples(
         query_examples,
         few_shot_examples,
     )
 
-    assert effective_query == query_examples
-    assert effective_few_shot == few_shot_examples
-    assert dummy_prompt.schema_generator_query_examples == query_examples
-    assert dummy_prompt.schema_generator_few_shot_examples == few_shot_examples
+    assert json.loads(effective_query) == [
+        {
+            "description": "who knows marko?",
+            "gremlin": "",
+        }
+    ]
+    assert json.loads(effective_few_shot) == {
+        "vertexlabels": [],
+        "edgelabels": [],
+    }
+    assert dummy_prompt.schema_generator_query_examples == effective_query
+    assert dummy_prompt.schema_generator_few_shot_examples == effective_few_shot
     assert dummy_prompt.update_count == 1
 
 
@@ -86,7 +135,7 @@ def test_schema_generator_persist_helper_rejects_invalid_query_examples(
     with pytest.raises(gr.Error, match="Query examples must be valid JSON"):
         vector_graph_block._persist_schema_generator_examples(
             "{invalid json",
-            "[]",
+            "{}",
         )
 
     assert dummy_prompt.schema_generator_query_examples == ""
@@ -100,8 +149,8 @@ def test_blank_schema_generator_examples_clear_persisted_overrides_to_bundled(
 ):
     _write_bundled_examples(tmp_path)
     dummy_prompt = DummyPrompt()
-    dummy_prompt.schema_generator_query_examples = '[{"saved_query": true}]'
-    dummy_prompt.schema_generator_few_shot_examples = '[{"saved_schema": true}]'
+    dummy_prompt.schema_generator_query_examples = '[{"description": "saved query", "gremlin": ""}]'
+    dummy_prompt.schema_generator_few_shot_examples = '{"vertexlabels": [{"name": "saved"}], "edgelabels": []}'
     monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
     monkeypatch.setattr(vector_graph_block, "resource_path", str(tmp_path))
 
@@ -112,8 +161,20 @@ def test_blank_schema_generator_examples_clear_persisted_overrides_to_bundled(
 
     assert dummy_prompt.schema_generator_query_examples == ""
     assert dummy_prompt.schema_generator_few_shot_examples == ""
-    assert json.loads(effective_query) == [{"bundled_query": True}]
-    assert json.loads(effective_few_shot) == [{"bundled_schema": True}]
+    assert json.loads(effective_query) == [
+        {
+            "description": "Find all persons",
+            "gremlin": "",
+        },
+        {
+            "description": "Find all webpages",
+            "gremlin": "",
+        },
+    ]
+    assert json.loads(effective_few_shot) == {
+        "vertexlabels": [],
+        "edgelabels": [],
+    }
     assert dummy_prompt.update_count == 1
 
 
@@ -134,19 +195,25 @@ def test_build_schema_feedback_persists_examples_before_running_flow(
 
     monkeypatch.setattr(vector_graph_block, "build_schema", fake_build_schema)
 
-    query_examples = '[{"query": "who knows lop?"}]'
-    few_shot_examples = '[{"schema": {"edges": []}}]'
-
     result = vector_graph_block._build_schema_and_provide_feedback(
         "source text",
-        query_examples,
-        few_shot_examples,
+        '["who knows lop?"]',
+        '{"vertexlabels": [], "edgelabels": []}',
     )
 
     assert result == "{}"
-    assert dummy_prompt.schema_generator_query_examples == query_examples
-    assert dummy_prompt.schema_generator_few_shot_examples == few_shot_examples
-    assert calls == [("source text", query_examples, few_shot_examples)]
+    assert calls
+    _, query_payload, few_shot_payload = calls[0]
+    assert json.loads(query_payload) == [
+        {
+            "description": "who knows lop?",
+            "gremlin": "",
+        }
+    ]
+    assert json.loads(few_shot_payload) == {
+        "vertexlabels": [],
+        "edgelabels": [],
+    }
 
 
 def test_build_schema_feedback_rejects_invalid_few_shot_before_flow(
@@ -180,15 +247,23 @@ def test_build_schema_feedback_rejects_invalid_few_shot_before_flow(
 
 def test_load_examples_prefers_persisted_prompt_values(monkeypatch):
     dummy_prompt = DummyPrompt()
-    dummy_prompt.schema_generator_query_examples = '[{"saved_query": true}]'
-    dummy_prompt.schema_generator_few_shot_examples = '[{"saved_schema": true}]'
+    dummy_prompt.schema_generator_query_examples = '[{"description": "saved query", "gremlin": ""}]'
+    dummy_prompt.schema_generator_few_shot_examples = '{"vertexlabels": [], "edgelabels": []}'
     monkeypatch.setattr(vector_graph_block, "prompt", dummy_prompt)
 
     query_examples = json.loads(vector_graph_block.load_query_examples())
     few_shot_examples = json.loads(vector_graph_block.load_schema_fewshot_examples())
 
-    assert query_examples == [{"saved_query": True}]
-    assert few_shot_examples == [{"saved_schema": True}]
+    assert query_examples == [
+        {
+            "description": "saved query",
+            "gremlin": "",
+        }
+    ]
+    assert few_shot_examples == {
+        "vertexlabels": [],
+        "edgelabels": [],
+    }
 
 
 def test_load_examples_falls_back_to_bundled_resources(monkeypatch, tmp_path):
@@ -200,8 +275,20 @@ def test_load_examples_falls_back_to_bundled_resources(monkeypatch, tmp_path):
     query_examples = json.loads(vector_graph_block.load_query_examples())
     few_shot_examples = json.loads(vector_graph_block.load_schema_fewshot_examples())
 
-    assert query_examples == [{"bundled_query": True}]
-    assert few_shot_examples == [{"bundled_schema": True}]
+    assert query_examples == [
+        {
+            "description": "Find all persons",
+            "gremlin": "",
+        },
+        {
+            "description": "Find all webpages",
+            "gremlin": "",
+        },
+    ]
+    assert few_shot_examples == {
+        "vertexlabels": [],
+        "edgelabels": [],
+    }
 
 
 def test_invalid_persisted_examples_fall_back_to_bundled_resources(
@@ -218,8 +305,20 @@ def test_invalid_persisted_examples_fall_back_to_bundled_resources(
     query_examples = json.loads(vector_graph_block.load_query_examples())
     few_shot_examples = json.loads(vector_graph_block.load_schema_fewshot_examples())
 
-    assert query_examples == [{"bundled_query": True}]
-    assert few_shot_examples == [{"bundled_schema": True}]
+    assert query_examples == [
+        {
+            "description": "Find all persons",
+            "gremlin": "",
+        },
+        {
+            "description": "Find all webpages",
+            "gremlin": "",
+        },
+    ]
+    assert few_shot_examples == {
+        "vertexlabels": [],
+        "edgelabels": [],
+    }
 
 
 def test_generic_store_prompt_does_not_handle_schema_generator_examples():


### PR DESCRIPTION
## Purpose

Closes #346.

This PR persists edited schema-generator query examples and few-shot schema examples in the demo.

## Changes

* Added prompt config fields for schema-generator query examples and few-shot schema examples.
* Load persisted schema-generator examples into the demo UI before falling back to bundled resource examples.
* Persist edited examples through the existing prompt config save path.
* Validate edited examples as JSON before saving.
* Reject invalid JSON with a clear UI error and avoid persisting invalid content.
* Keep bundled examples under `resources/prompt_examples` read-only as defaults.
* Added tests for save/load behavior, invalid JSON handling, bundled fallback behavior, invalid persisted fallback behavior, UI persistence wiring, and old prompt config compatibility.

## Tests

* `uv run ruff check hugegraph-llm/src/hugegraph_llm/config/models/base_prompt_config.py hugegraph-llm/src/hugegraph_llm/demo/rag_demo/vector_graph_block.py hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py`
* `uv run ruff format --check .`
* `uv run pytest hugegraph-llm/src/tests/document/test_schema_generator_examples_persistence.py`
* `uv run pytest hugegraph-llm/src/tests/document`
