### PR TITLE
chore: introduce ty for type checking (non-blocking)

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -49,3 +49,9 @@ jobs:
       - name: Lint code with Ruff
         run: |
           uv run ruff check .
+
+      - name: Type check with ty (non-blocking)
+        run: uv run ty check hugegraph-llm/src hugegraph-python-client/src
+        continue-on-error: true
+        # TODO: extend scope to hugegraph-ml once heavy optional deps (DGL, PyTorch) are handled
+        # TODO: add graph-mcp once the module is introduced

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dev dependencies
         run: |
-          uv sync --extra dev
+          uv sync --extra dev --extra llm --extra python-client
 
       - name: Check code formatting with Ruff
         run: |

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dev dependencies
         run: |
-          uv sync --extra dev --extra llm --extra python-client
+          uv sync --extra dev
 
       - name: Check code formatting with Ruff
         run: |
@@ -50,8 +50,42 @@ jobs:
         run: |
           uv run ruff check .
 
+  ty-check:
+    runs-on: ubuntu-latest
+    continue-on-error: true   # non-blocking during ramp-up
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]   # hugegraph-llm requires <3.12
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Cache dependencies
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            ~/.cache/pip
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
+
+      - name: Install dev + runtime extras
+        run: |
+          uv sync --extra dev --extra llm --extra python-client
+
       - name: Type check with ty (non-blocking)
         run: uv run ty check hugegraph-llm/src hugegraph-python-client/src
-        continue-on-error: true
         # TODO: extend scope to hugegraph-ml once heavy optional deps (DGL, PyTorch) are handled
         # TODO: add graph-mcp once the module is introduced

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -52,7 +52,6 @@ jobs:
 
   ty-check:
     runs-on: ubuntu-latest
-    continue-on-error: true   # non-blocking during ramp-up
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]   # hugegraph-llm requires <3.12
@@ -87,5 +86,6 @@ jobs:
 
       - name: Type check with ty (non-blocking)
         run: uv run ty check hugegraph-llm/src hugegraph-python-client/src
+        continue-on-error: true
         # TODO: extend scope to hugegraph-ml once heavy optional deps (DGL, PyTorch) are handled
         # TODO: add graph-mcp once the module is introduced

--- a/hugegraph-llm/pyproject.toml
+++ b/hugegraph-llm/pyproject.toml
@@ -100,11 +100,6 @@ allow-direct-references = true
 hugegraph-python-client = { workspace = true }
 pycgraph = { git = "https://github.com/ChunelFeng/CGraph.git", subdirectory = "python", tag = "v3.2.2", marker = "platform_machine == 'aarch64'" }
 
-[tool.mypy]
-disable_error_code = ["import-untyped"]
-check_untyped_defs = true
-disallow_untyped_defs = false
-
 [tool.ruff]
 line-length = 120
 indent-width = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "pylint~=3.0.0",
     "ruff>=0.11.0",
     "mypy>=1.16.1",
-    "ty>=0.0.51",  # pre-stable (0.0.x): consider tight pinning (ty==0.0.51) to avoid surprise breakage between releases
+    "ty>=0.0.51",  # pre-stable (0.0.x): consider tight pinning to avoid surprise breakage
     "pre-commit>=3.5.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pylint~=3.0.0",
     "ruff>=0.11.0",
     "mypy>=1.16.1",
+    "ty>=0.0.51",  # pre-stable (0.0.x): consider tight pinning (ty==0.0.51) to avoid surprise breakage between releases
     "pre-commit>=3.5.0",
 ]
 
@@ -197,3 +198,6 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
 docstring-code-format = true
+
+[tool.ty.rules]
+# Start permissive; tighten incrementally as errors are fixed


### PR DESCRIPTION
Closes #364  
  
## What  
  
Introduces `ty` (Astral's Rust-based type checker) to the project in non-blocking mode as the first step of a gradual adoption plan.  
  
## Changes  
  
- **`pyproject.toml`** — add `ty>=0.0.51` to `dev` optional dependencies; add `[tool.ty.rules]` placeholder section  
- **`hugegraph-llm/pyproject.toml`** — remove the `[tool.mypy]` block (its three settings are either unsupported or default behavior in ty)  
- **`.github/workflows/ruff.yml`** — add `ty check` step with `continue-on-error: true` so errors are reported but do not fail CI during ramp-up  
  
## Why non-blocking  
  
`ty` runs on every PR and surfaces type errors in the CI log, but `continue-on-error: true` keeps the build green. Once errors are fixed incrementally (file by file in follow-up PRs), `continue-on-error: true` will be removed to enforce the check.  
  
## Scope  
  
Covers `hugegraph-llm/src` and `hugegraph-python-client/src` only.    
`hugegraph-ml` is deferred due to heavy optional deps (DGL, PyTorch).    
`graph-mcp` will be added once the module is introduced.